### PR TITLE
Fix CodeRabbit config path lookup in review workflow

### DIFF
--- a/src/rouge/core/workflow/review.py
+++ b/src/rouge/core/workflow/review.py
@@ -18,8 +18,8 @@ def generate_review(
 
     Args:
         review_file: Path where review should be saved
-        working_dir: Working directory for CodeRabbit command
-        repo_path: Repository root path
+        working_dir: Working directory (unused, kept for backward compatibility)
+        repo_path: Repository root path where .coderabbit.yaml config is located
         issue_id: Rouge issue ID for tracking
 
     Returns:
@@ -31,8 +31,8 @@ def generate_review(
         if review_dir:
             os.makedirs(review_dir, exist_ok=True)
 
-        # Build absolute config path and validate it exists
-        config_path = os.path.join(working_dir, ".coderabbit.yaml")
+        # Build absolute config path and validate it exists (config must be in repo root)
+        config_path = os.path.join(repo_path, ".coderabbit.yaml")
         if not os.path.exists(config_path):
             return StepResult.fail(f"CodeRabbit config not found at {config_path}")
         logger.debug(f"Using CodeRabbit config at {config_path}")


### PR DESCRIPTION
## Description

Fixes a bug in the CodeRabbit review generation workflow where the config file path was incorrectly constructed using `working_dir` instead of `repo_path`. The CodeRabbit config file (`.coderabbit.yaml`) is conventionally stored at the repository root, so it should be looked up using `repo_path`.

This bug would cause the config file lookup to fail when `working_dir` differs from `repo_path`, preventing the review generation step from succeeding.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Updated `generate_review()` to use `repo_path` instead of `working_dir` for CodeRabbit config path
- Improved documentation to clarify that `working_dir` is kept for backward compatibility
- Added comment explaining that config must be in repo root

## How to Test

- [ ] Verify CodeRabbit review generation works when `working_dir` differs from `repo_path`
- [ ] Confirm config file is correctly located at repository root
- [ ] Run existing tests to ensure no regression