### PR TITLE
Enable artifacts by default in execute_workflow

### DIFF
--- a/src/rouge/core/workflow/runner.py
+++ b/src/rouge/core/workflow/runner.py
@@ -36,5 +36,5 @@ def execute_workflow(
         True if workflow completed successfully, False otherwise
     """
     pipeline = get_default_pipeline()
-    runner = WorkflowRunner(pipeline)
+    runner = WorkflowRunner(pipeline, enable_artifacts=True)
     return runner.run(issue_id, adw_id)


### PR DESCRIPTION
## Description

Fixes an issue where artifacts were not being      
  persisted when using the `execute_workflow` convenience function. The             
  `WorkflowRunner` was being instantiated without the `enable_artifacts` parameter, 
  defaulting to `False` and causing artifacts to not be saved.

## Type of        
  Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore   
  (non-breaking change for tech debt or devx improvements)
- [ ] Feature           
  (non-breaking change which adds functionality)
- [ ] Breaking change (fix or     
  feature that would cause existing functionality to not work as expected)
- [ ]   
  This change requires a documentation update

## What Changed

- Pass          
  `enable_artifacts=True` to `WorkflowRunner` constructor in `execute_workflow`     
  function to ensure artifacts are automatically persisted

## How to Test

- [ 
  ] Run a workflow using `uv run rouge run <issue-id>` and verify artifacts are     
  saved to `.rouge/workflows/<workflow-id>/`
- [ ] Run `uv run pytest tests/` to   
  ensure no regressions