### PR TITLE
Stream Task tool invocations to workflow comments

### DIFF
--- a/src/rouge/core/agents/claude/claude.py
+++ b/src/rouge/core/agents/claude/claude.py
@@ -140,7 +140,7 @@ def convert_jsonl_to_json(jsonl_file: str) -> str:
 
 
 def iter_assistant_items(line: str) -> Iterable[Dict[str, Any]]:
-    """Yield assistant text/TodoWrite items parsed from a Claude CLI stdout line.
+    """Yield assistant text/TodoWrite/Task items parsed from a Claude CLI stdout line.
 
     This function is critical for real-time streaming progress comments.
     It parses JSONL lines and extracts relevant content items from assistant messages.
@@ -173,8 +173,9 @@ def iter_assistant_items(line: str) -> Iterable[Dict[str, Any]]:
         item_type = item.get("type")
         is_text = item_type == "text"
         is_todo = item_type == "tool_use" and item.get("name") == "TodoWrite"
+        is_task = item_type == "tool_use" and item.get("name") == "Task"
 
-        if is_text or is_todo:
+        if is_text or is_todo or is_task:
             selected.append(item)
     return selected
 

--- a/tests/test_agents_claude.py
+++ b/tests/test_agents_claude.py
@@ -122,6 +122,32 @@ def test_iter_assistant_items_non_assistant():
     assert len(items) == 0
 
 
+def test_iter_assistant_items_includes_task_tool_use():
+    """Test extracting Task tool_use items from JSONL line."""
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Starting implementation"},
+                    {
+                        "type": "tool_use",
+                        "name": "Task",
+                        "input": {"action": "create", "task_id": "task-123"},
+                    },
+                    {"type": "tool_use", "name": "OtherTool", "input": {}},
+                ]
+            },
+        }
+    )
+    items = list(iter_assistant_items(line))
+    assert len(items) == 2
+    assert items[0]["type"] == "text"
+    assert items[1]["type"] == "tool_use"
+    assert items[1]["name"] == "Task"
+    assert items[1]["input"] == {"action": "create", "task_id": "task-123"}
+
+
 def test_save_prompt(tmp_path, monkeypatch):
     """Test saving prompt to file."""
     monkeypatch.setenv("ROUGE_AGENTS_DIR", str(tmp_path))


### PR DESCRIPTION
## Description

This change enhances the real-time streaming capability of the Claude agent by including Task tool invocations in workflow progress comments. Previously, only text and TodoWrite tool uses were captured and streamed; now Task tool uses are also included, providing better visibility into agent operations during workflow execution.

This improvement allows developers to monitor when agents launch subtasks in real-time, improving debugging and workflow transparency.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Extended `iter_assistant_items` function to filter and include Task tool_use items
- Updated function docstring to document Task tool support
- Added test case `test_iter_assistant_items_includes_task_tool_use` to verify Task tool extraction

## How to Test

- [ ] Run `uv run pytest tests/test_agents_claude.py::test_iter_assistant_items_includes_task_tool_use` to verify Task tool extraction
- [ ] Run full test suite with `uv run pytest` to ensure no regressions
- [ ] Execute a workflow that uses Task tool invocations and verify they appear in progress comments