### PR TITLE
chore(workflow): remove enable_artifacts parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ Artifact-focused commands:
 
 Single-step execution requires artifacts from a prior run (or manually created
 files in the workflow directory). Full workflow execution (`rouge run`,
-`rouge-adw`, `rouge-worker`) does not enable artifacts by default; use the
-step/artifact commands after a run that generated artifacts.
+`rouge-adw`, `rouge-worker`) always enables artifacts; use the step/artifact
+commands to inspect or modify artifacts after a run.
 
 If you run `rouge step run` outside the project directory, pass `--working-dir`
 to load `.env` from that directory (or its parent), matching the worker's

--- a/src/rouge/cli/step.py
+++ b/src/rouge/cli/step.py
@@ -116,7 +116,7 @@ def run_step(
     typer.echo(f"Running step '{step_name}' for issue {issue_id} (workflow: {adw_id})")
 
     pipeline = get_default_pipeline()
-    runner = WorkflowRunner(pipeline, enable_artifacts=True)
+    runner = WorkflowRunner(pipeline)
 
     try:
         success = runner.run_single_step(

--- a/src/rouge/core/workflow/pipeline.py
+++ b/src/rouge/core/workflow/pipeline.py
@@ -18,15 +18,13 @@ class WorkflowRunner:
     continuing past best-effort step failures.
     """
 
-    def __init__(self, steps: List[WorkflowStep], enable_artifacts: bool = False) -> None:
+    def __init__(self, steps: List[WorkflowStep]) -> None:
         """Initialize the runner with a list of steps.
 
         Args:
             steps: Ordered list of workflow steps to execute
-            enable_artifacts: Whether to enable artifact persistence
         """
         self._steps = steps
-        self._enable_artifacts = enable_artifacts
 
     def run(self, issue_id: int, adw_id: str) -> bool:
         """Execute all workflow steps in sequence.
@@ -38,11 +36,9 @@ class WorkflowRunner:
         Returns:
             True if workflow completed successfully, False if a critical step failed
         """
-        # Create artifact store if enabled
-        artifact_store: Optional[ArtifactStore] = None
-        if self._enable_artifacts:
-            artifact_store = ArtifactStore(adw_id)
-            logger.debug("Artifact persistence enabled at %s", artifact_store.workflow_dir)
+        # Create artifact store unconditionally
+        artifact_store = ArtifactStore(adw_id)
+        logger.debug("Artifact persistence enabled at %s", artifact_store.workflow_dir)
 
         context = WorkflowContext(
             issue_id=issue_id,

--- a/src/rouge/core/workflow/runner.py
+++ b/src/rouge/core/workflow/runner.py
@@ -36,5 +36,5 @@ def execute_workflow(
         True if workflow completed successfully, False otherwise
     """
     pipeline = get_default_pipeline()
-    runner = WorkflowRunner(pipeline, enable_artifacts=True)
+    runner = WorkflowRunner(pipeline)
     return runner.run(issue_id, adw_id)


### PR DESCRIPTION
## Description

This change removes the `enable_artifacts` parameter from `WorkflowRunner` since artifact persistence is now always enabled by default. This simplifies the workflow runner API by eliminating unnecessary conditional logic and reducing cognitive overhead when using the workflow system.

This is a chore that improves code maintainability and developer experience by removing a configuration option that was no longer optional.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Removed `enable_artifacts` parameter from `WorkflowRunner.__init__` constructor
- Updated `execute_workflow` and `run_step` functions to not pass `enable_artifacts` argument
- Removed conditional artifact store creation logic (now unconditionally creates artifact store)
- Updated README.md documentation to reflect that artifacts are always enabled
- Simplified workflow runner API by removing an unnecessary configuration option

## How to Test

- [ ] Run `uv run rouge run <issue-id>` and verify artifacts are created in workflow directory
- [ ] Run `uv run rouge-adw <issue-id>` and verify artifacts are persisted
- [ ] Run `uv run rouge step run <step-name> <issue-id> <adw-id>` and verify it works with artifacts
- [ ] Verify that the workflow runner no longer accepts `enable_artifacts` parameter
- [ ] Run existing tests with `uv run pytest` to ensure no regressions