### PR TITLE
Fix SetupStep test isolation to prevent real git operations

### DIFF
--- a/tests/test_setup_step.py
+++ b/tests/test_setup_step.py
@@ -150,8 +150,9 @@ def test_setup_step_default_branch_fallback(
 # === Safety Check Tests ===
 
 
-def test_setup_step_destructive_ops_not_allowed_by_default(context):
+def test_setup_step_destructive_ops_not_allowed_by_default(context, monkeypatch):
     """Test setup fails when ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS is not set."""
+    monkeypatch.delenv("ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS", raising=False)
     step = SetupStep()
     result = step.run(context)
 
@@ -160,9 +161,9 @@ def test_setup_step_destructive_ops_not_allowed_by_default(context):
     assert "ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS=true" in result.error
 
 
-@patch.dict("os.environ", {"ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS": "false"})
-def test_setup_step_destructive_ops_explicitly_disabled(context):
+def test_setup_step_destructive_ops_explicitly_disabled(context, monkeypatch):
     """Test setup fails when ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS is explicitly set to false."""
+    monkeypatch.setenv("ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS", "false")
     step = SetupStep()
     result = step.run(context)
 


### PR DESCRIPTION
## Description

Fixes a bug where SetupStep tests could run real git commands (checkout, reset --hard, checkout -b) when the `ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS` environment variable was set in the shell. This caused test pollution, created unexpected branches, and could discard uncommitted changes when running the test suite.

The root cause was that `@patch.dict(\"os.environ\", {...})` merges with the existing environment rather than replacing it, and one test had no environment setup at all, assuming the variable would be unset.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- `test_setup_step_destructive_ops_not_allowed_by_default`: now uses `monkeypatch.delenv()` to explicitly unset `ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS`
- `test_setup_step_destructive_ops_explicitly_disabled`: replaced `@patch.dict` with `monkeypatch.setenv()` for proper isolation

## How to Test

- [ ] Run `uv run pytest tests/test_setup_step.py -v` and verify all 21 tests pass
- [ ] Run `uv run pytest tests/ -v` and verify no tests fail (374 should pass)
- [ ] Verify no `adw-test123` branch is created locally after running tests