### PR TITLE
Add nullable adw_id migration 

### DIFF
--- a/migrations/007_allow_null_adw_id.py
+++ b/migrations/007_allow_null_adw_id.py
@@ -1,0 +1,33 @@
+"""
+Allow issues.adw_id to be nullable.
+
+Drops the NOT NULL constraint on issues.adw_id. Rollback backfills any NULLs
+to avoid constraint violations, then re-applies NOT NULL.
+"""
+
+from yoyo import step
+
+__depends__ = {"006_remove_lock_rpc"}
+
+# Forward migration: drop NOT NULL constraint
+# Rollback: re-apply NOT NULL constraint (runs second during rollback)
+step(
+    """
+    ALTER TABLE issues ALTER COLUMN adw_id DROP NOT NULL;
+    """,
+    """
+    ALTER TABLE issues ALTER COLUMN adw_id SET NOT NULL;
+    """,
+)
+
+# Rollback: backfill NULLs before re-applying NOT NULL (runs first during rollback)
+# Note: The issues table is expected to remain small (< 10k rows). If the table
+# grows significantly, consider implementing batched updates to avoid long locks.
+step(
+    None,  # No forward action for this step
+    """
+    UPDATE issues
+    SET adw_id = substring(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)
+    WHERE adw_id IS NULL;
+    """,
+)


### PR DESCRIPTION
## Description

Add migration 007 to make `issues.adw_id` nullable . The migration properly handles rollback by backfilling NULL values with generated UUIDs before re-applying the NOT NULL constraint.

## Type of Change

- [x] Feature (new migration for schema flexibility)
- [ ] Chore (configuration update for review automation)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## What Changed

- Added migration 007 to drop NOT NULL constraint on `issues.adw_id`
- Configured rollback to backfill NULL values with generated 8-character UUIDs
- Ensured correct step order so backfill runs before constraint re-application
- Added table size expectations comment to prevent lock issues on growth

## How to Test

- [x] Run migration forward: verify NOT NULL constraint is dropped
- [x] Run migration rollback: verify NULLs are backfilled with UUIDs and constraint re-applied
- [x] Verify migration step order ensures safe rollback execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied database schema update to allow null values for a specific field, with automatic rollback support and data integrity safeguards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->