### PR TITLE
Add DEFAULT_GIT_BRANCH to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,9 @@ ANTHROPIC_API_KEY=sk-your-anthropic-api-key
 # Working directory for agent commands and CodeRabbit execution (defaults to current directory)
 # WORKING_DIR=/absolute/path/to/working/directory
 
+# Default git branch to checkout during setup (defaults to "main")
+# DEFAULT_GIT_BRANCH=main
+
 # Allow destructive git operations (git reset --hard) in workflow setup step.
 # Set to "true" to enable. Required for workflow execution but will discard uncommitted changes.
 # WARNING: Only enable this in worker environments or when you're sure you want to reset git state.


### PR DESCRIPTION
Adds missing .env var to .env.example for reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment configuration example file with an additional sample configuration option for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->