### PR TITLE
Fix .env loading to respect current working directory

### DIFF
--- a/src/rouge/core/database.py
+++ b/src/rouge/core/database.py
@@ -28,7 +28,11 @@ def init_db_env(dotenv_path: Optional[Path] = None) -> None:
         load_dotenv(dotenv_path)
     else:
         # Ensure we search from the current working directory, not the caller's file path.
-        load_dotenv(find_dotenv(usecwd=True))
+        found_path = find_dotenv(usecwd=True)
+        if found_path:
+            load_dotenv(found_path)
+        else:
+            logger.debug("No .env file found from cwd search; skipping dotenv load")
 
 
 class SupabaseConfig:


### PR DESCRIPTION
## Description

Loads .env from the current working directory when no explicit path is provided, ensuring worker runs pick up local configuration. No new dependencies.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Adjusted env loading to search from cwd when no path is supplied

## How to Test

- [x] Run `rouge-worker --worker-id xwing-1` in a directory with `.env`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved environment variable loading to search the current working directory for configuration files and log when none are found, increasing reliability of startup configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->