### PR TITLE
Mark locked issues as started in get_and_lock_next_issue

### DIFF
--- a/migrations/009_lock_issue_sets_started.py
+++ b/migrations/009_lock_issue_sets_started.py
@@ -1,0 +1,53 @@
+"""
+Update get_and_lock_next_issue to mark issues as started when locked.
+"""
+
+from yoyo import step
+
+__depends__ = {"008_restore_lock_rpc"}
+
+step(
+    """
+    CREATE OR REPLACE FUNCTION get_and_lock_next_issue(p_worker_id worker_id)
+    RETURNS TABLE(issue_id INT, issue_description TEXT, issue_status TEXT, issue_type TEXT)
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+        RETURN QUERY
+        WITH next_issue AS (
+            SELECT i.id
+            FROM issues i
+            WHERE i.type IN ('main', 'patch')
+              AND i.status = 'pending'
+              AND i.assigned_to = p_worker_id
+            ORDER BY i.id
+            FOR UPDATE SKIP LOCKED
+            LIMIT 1
+        )
+        UPDATE issues i
+        SET status = 'started'
+        FROM next_issue
+        WHERE i.id = next_issue.id
+        RETURNING i.id, i.description, i.status, i.type;
+    END;
+    $$;
+    """,
+    """
+    CREATE OR REPLACE FUNCTION get_and_lock_next_issue(p_worker_id worker_id)
+    RETURNS TABLE(issue_id INT, issue_description TEXT, issue_status TEXT, issue_type TEXT)
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+        RETURN QUERY
+        SELECT i.id, i.description, i.status, i.type
+        FROM issues i
+        WHERE i.type IN ('main', 'patch')
+          AND i.status = 'pending'
+          AND i.assigned_to = p_worker_id
+        ORDER BY i.id
+        FOR UPDATE SKIP LOCKED
+        LIMIT 1;
+    END;
+    $$;
+    """,
+)


### PR DESCRIPTION
## Description

Update the lock RPC so issues are atomically moved to started when claimed, preventing repeated workflows on pending issues. No new dependencies.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Updated the get_and_lock_next_issue RPC to set status to started on lock
- Added a migration to apply the new RPC behavior

## How to Test

- [ ] Apply migrations and run a worker to confirm locked issues are marked started
