### PR TITLE
Fix workflow error status handling in worker

### DIFF
--- a/src/rouge/worker/worker.py
+++ b/src/rouge/worker/worker.py
@@ -200,16 +200,16 @@ class IssueWorker:
                     issue_id,
                     result.returncode,
                 )
-                update_issue_status(issue_id, "pending", self.logger)
+                update_issue_status(issue_id, "failed", self.logger)
                 return adw_id, False
 
         except subprocess.TimeoutExpired:
             self._handle_workflow_failure(issue_id, workflow_type, "Workflow timed out")
-            update_issue_status(issue_id, "pending", self.logger)
+            update_issue_status(issue_id, "failed", self.logger)
             return adw_id, False
         except Exception:
             self._handle_workflow_failure(issue_id, workflow_type, "Unexpected error in workflow")
-            update_issue_status(issue_id, "pending", self.logger)
+            update_issue_status(issue_id, "failed", self.logger)
             return adw_id, False
 
     def execute_workflow(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -131,7 +131,7 @@ class TestExecuteWorkflow:
                 result = worker.execute_workflow(123, "Test issue", "pending", "main")
 
                 assert result is False
-                mock_update.assert_called_once_with(123, "pending", worker.logger)
+                mock_update.assert_called_once_with(123, "failed", worker.logger)
 
     def test_execute_workflow_timeout(self, worker):
         """Test workflow execution timeout."""
@@ -140,7 +140,7 @@ class TestExecuteWorkflow:
                 result = worker.execute_workflow(123, "Test issue", "pending", "main")
 
                 assert result is False
-                mock_update.assert_called_once_with(123, "pending", worker.logger)
+                mock_update.assert_called_once_with(123, "failed", worker.logger)
 
     def test_execute_workflow_exception(self, worker):
         """Test workflow execution with unexpected exception."""
@@ -149,7 +149,7 @@ class TestExecuteWorkflow:
                 result = worker.execute_workflow(123, "Test issue", "pending", "main")
 
                 assert result is False
-                mock_update.assert_called_once_with(123, "pending", worker.logger)
+                mock_update.assert_called_once_with(123, "failed", worker.logger)
 
     def test_execute_workflow_command_format(self, worker):
         """Test workflow command is formatted correctly."""


### PR DESCRIPTION
## Description

Fixed incorrect status updates in the IssueWorker when workflows fail. Previously, failed workflows were incorrectly marked as 'pending' instead of 'failed', making it impossible to distinguish between issues that are waiting to be processed and those that have already failed.

Resolves #45 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Updated workflow error handlers to set status to 'failed' instead of 'pending'
- Fixed status updates for three error cases: non-zero exit codes, timeouts, and unexpected exceptions
- Updated corresponding test assertions to verify correct 'failed' status

## How to Test

- [ ] Run a workflow that exits with non-zero code and verify issue status is set to 'failed'
- [ ] Trigger a workflow timeout and verify issue status is set to 'failed'
- [ ] Cause an unexpected exception during workflow execution and verify issue status is set to 'failed'
- [ ] Run test suite: `uv run pytest tests/test_worker.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow status handling so that failed workflows are now correctly marked as "failed" instead of "pending" when they fail, timeout, or encounter exceptions. This ensures accurate status representation across all failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->