### PR TITLE
Fix codereview base commit handling in CodeReviewStep

### DIFF
--- a/src/rouge/core/workflow/steps/code_review_step.py
+++ b/src/rouge/core/workflow/steps/code_review_step.py
@@ -172,8 +172,13 @@ class CodeReviewStep(WorkflowStep):
 
         repo_path = get_repo_path()
 
-        # Read base_commit from plan_data.plan field (plan contains the base commit string)
-        base_commit = plan_data.plan if plan_data.plan else None
+        # Only codereview workflows should pass a base commit to CodeRabbit.
+        # Main/patch workflows use plan_data.plan for markdown content, not a git SHA.
+        base_commit = None
+        if context.data.get("workflow_type") == "codereview":
+            base_commit = context.data.get("base_commit")
+            if not base_commit and plan_data.plan:
+                base_commit = plan_data.plan
 
         review_result = self._generate_review(
             repo_path, context.issue_id, context.adw_id, base_commit=base_commit

--- a/src/rouge/core/workflow/steps/review_plan_step.py
+++ b/src/rouge/core/workflow/steps/review_plan_step.py
@@ -159,7 +159,8 @@ class ReviewPlanStep(WorkflowStep):
         # Store plan data in context (plan field contains base_commit)
         context.data["plan_data"] = derive_response.data
 
-        # Also store base_commit directly in context for convenience
+        # Also store codereview metadata directly in context for downstream steps.
+        context.data["workflow_type"] = "codereview"
         context.data["base_commit"] = derive_response.data.plan
 
         # Save artifact if artifact store is available

--- a/tests/test_code_review_step.py
+++ b/tests/test_code_review_step.py
@@ -1,7 +1,7 @@
 """Tests for CodeReviewStep workflow step."""
 
 import subprocess
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 
@@ -193,20 +193,124 @@ class TestCodeReviewStepRun:
 
     @patch("rouge.core.workflow.steps.code_review_step.emit_comment_from_payload")
     @patch.object(CodeReviewStep, "_generate_review")
-    def test_run_standalone_workflow_without_issue_id(
+    def test_run_uses_base_commit_for_codereview_workflow(
+        self,
+        mock__generate_review,
+        mock_emit_comment,
+        mock_context,
+        sample_plan_data,
+        sample_review_data,
+    ):
+        """Test codereview workflow passes base_commit from context to CodeRabbit."""
+        mock_context.data = {
+            "plan_data": sample_plan_data,
+            "workflow_type": "codereview",
+            "base_commit": "abc1234",
+        }
+
+        def load_artifact_if_missing(context_key, _artifact_type, _artifact_class, _extract_fn):
+            return mock_context.data.get(context_key)
+
+        mock_context.load_artifact_if_missing = load_artifact_if_missing
+        mock__generate_review.return_value = StepResult.ok(sample_review_data)
+        mock_emit_comment.return_value = ("success", "Comment inserted")
+
+        step = CodeReviewStep()
+        result = step.run(mock_context)
+
+        assert result.success is True
+        mock__generate_review.assert_called_once_with(
+            ANY,
+            mock_context.issue_id,
+            mock_context.adw_id,
+            base_commit="abc1234",
+        )
+
+    @patch("rouge.core.workflow.steps.code_review_step.emit_comment_from_payload")
+    @patch.object(CodeReviewStep, "_generate_review")
+    def test_run_falls_back_to_plan_data_for_codereview_workflow(
         self,
         mock__generate_review,
         mock_emit_comment,
         mock_context,
         sample_review_data,
     ):
+        """Test codereview workflow falls back to plan_data.plan when base_commit is missing."""
+        plan_data = PlanData(plan="def5678", summary="Derived base commit", session_id="session-123")
+        mock_context.data = {
+            "plan_data": plan_data,
+            "workflow_type": "codereview",
+        }
+
+        def load_artifact_if_missing(context_key, _artifact_type, _artifact_class, _extract_fn):
+            return mock_context.data.get(context_key)
+
+        mock_context.load_artifact_if_missing = load_artifact_if_missing
+        mock__generate_review.return_value = StepResult.ok(sample_review_data)
+        mock_emit_comment.return_value = ("success", "Comment inserted")
+
+        step = CodeReviewStep()
+        result = step.run(mock_context)
+
+        assert result.success is True
+        mock__generate_review.assert_called_once_with(
+            ANY,
+            mock_context.issue_id,
+            mock_context.adw_id,
+            base_commit="def5678",
+        )
+
+    @patch("rouge.core.workflow.steps.code_review_step.emit_comment_from_payload")
+    @patch.object(CodeReviewStep, "_generate_review")
+    def test_run_does_not_use_plan_as_base_commit_for_non_codereview_workflow(
+        self,
+        mock__generate_review,
+        mock_emit_comment,
+        mock_context,
+        sample_plan_data,
+        sample_review_data,
+    ):
+        """Test patch/main workflows never use plan markdown as CodeRabbit base_commit."""
+        mock_context.data = {
+            "plan_data": sample_plan_data,
+            "workflow_type": "patch",
+        }
+
+        def load_artifact_if_missing(context_key, _artifact_type, _artifact_class, _extract_fn):
+            return mock_context.data.get(context_key)
+
+        mock_context.load_artifact_if_missing = load_artifact_if_missing
+        mock__generate_review.return_value = StepResult.ok(sample_review_data)
+        mock_emit_comment.return_value = ("success", "Comment inserted")
+
+        step = CodeReviewStep()
+        result = step.run(mock_context)
+
+        assert result.success is True
+        mock__generate_review.assert_called_once_with(
+            ANY,
+            mock_context.issue_id,
+            mock_context.adw_id,
+            base_commit=None,
+        )
+
+    @patch("rouge.core.workflow.steps.code_review_step.emit_comment_from_payload")
+    @patch.object(CodeReviewStep, "_generate_review")
+    def test_run_standalone_workflow_without_issue_id(
+        self,
+        mock__generate_review,
+        mock_emit_comment,
+        mock_context,
+        sample_plan_data,
+        sample_review_data,
+    ):
         """Test that standalone codereview workflow works without issue_id."""
         # Standalone workflow: no issue_id
         mock_context.issue_id = None
-        mock_context.data = {}
+        mock_context.data = {"plan_data": sample_plan_data}
 
-        def load_artifact_if_missing(_context_key, _artifact_type, _artifact_class, _extract_fn):
-            return None
+        def load_artifact_if_missing(context_key, _artifact_type, _artifact_class, _extract_fn):
+            return mock_context.data.get(context_key)
 
         mock_context.load_artifact_if_missing = load_artifact_if_missing
 


### PR DESCRIPTION
## Description

Fixes a regression where patch workflow plan markdown was incorrectly passed to CodeRabbit as `--base-commit`, causing `git diff` failures during review. The change scopes base-commit resolution to codereview runs only and preserves codereview restart/single-step compatibility by falling back to `plan_data.plan` only within that workflow context. No additional dependencies are required.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Added a codereview workflow marker in `ReviewPlanStep` context metadata.
- Guarded `CodeReviewStep` base-commit resolution so only codereview passes `--base-commit`.
- Added regression tests for codereview base-commit usage and non-codereview behavior.

## How to Test

- [x] Run `uv run pytest tests/test_code_review_step.py -q`
- [x] Run `uv run pytest tests/ -v`
- [x] Verify patch workflow review does not invoke `git diff` with patch-plan markdown


@coderabbitai ignore
