### PR TITLE
fix(workflow): fail codereview when review-plan returns INVALID

### DIFF
--- a/src/rouge/core/workflow/steps/review_plan_step.py
+++ b/src/rouge/core/workflow/steps/review_plan_step.py
@@ -115,6 +115,11 @@ class ReviewPlanStep(WorkflowStep):
         if "base_commit" not in parsed_data or not parsed_data["base_commit"].strip():
             return StepResult.fail("base_commit is required in review plan response")
         base_commit = parsed_data["base_commit"].strip()
+        if base_commit.upper() == "INVALID":
+            return StepResult.fail(
+                "Unsupported review format. Use 'review from base commit <ref>' or "
+                "'review from <sha>'."
+            )
         summary = parsed_data.get("summary", "")
 
         # Store base_commit as the plan field and summary as rationale

--- a/tests/test_review_plan_step.py
+++ b/tests/test_review_plan_step.py
@@ -1,0 +1,53 @@
+"""Tests for ReviewPlanStep base commit extraction behavior."""
+
+from unittest.mock import patch
+
+from rouge.core.agents.claude import ClaudeAgentPromptResponse
+from rouge.core.models import Issue
+from rouge.core.workflow.steps.review_plan_step import ReviewPlanStep
+
+
+def _sample_issue() -> Issue:
+    return Issue(
+        id=123,
+        description="review from base commit HEAD~3",
+        status="pending",
+        type="main",
+        adw_id="adw-test-review-plan",
+    )
+
+
+@patch("rouge.core.workflow.steps.review_plan_step.execute_template")
+def test_derive_base_commit_accepts_valid_ref(mock_execute_template) -> None:
+    """ReviewPlanStep should accept valid extracted refs like HEAD~3."""
+    mock_execute_template.return_value = ClaudeAgentPromptResponse(
+        output='{"output":"plan","base_commit":"HEAD~3","summary":"Using explicit base commit."}',
+        success=True,
+        session_id="sess-1",
+    )
+
+    step = ReviewPlanStep()
+    result = step._derive_base_commit(_sample_issue(), "adw-1")
+
+    assert result.success is True
+    assert result.data is not None
+    assert result.data.plan == "HEAD~3"
+
+
+@patch("rouge.core.workflow.steps.review_plan_step.execute_template")
+def test_derive_base_commit_fails_on_invalid_sentinel(mock_execute_template) -> None:
+    """ReviewPlanStep should fail when command returns INVALID sentinel token."""
+    mock_execute_template.return_value = ClaudeAgentPromptResponse(
+        output=(
+            '{"output":"plan","base_commit":"INVALID","summary":"Unsupported format."}'
+        ),
+        success=True,
+        session_id="sess-2",
+    )
+
+    step = ReviewPlanStep()
+    result = step._derive_base_commit(_sample_issue(), "adw-2")
+
+    assert result.success is False
+    assert result.error is not None
+    assert "Unsupported review format" in result.error


### PR DESCRIPTION
## Description

Make the codereview review-plan step fail fast when `/adw-review-plan` returns the `INVALID` sentinel for unsupported issue description formats, instead of passing that token downstream as a base commit.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Added validation in `ReviewPlanStep` to reject `base_commit == "INVALID"` (case-insensitive).
- Returned an actionable failure message instructing supported formats.
- Added unit tests for valid `HEAD~3` extraction and `INVALID` failure behavior.

## How to Test

- [x] `uv run ruff check src/`
- [x] `uv run black --check src/`
- [x] `uv run mypy`
- [x] `uv run pytest tests/test_review_plan_step.py -v`
