### PR TITLE
Centralize coding standards and point AGENTS to canonical guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,15 +44,9 @@ Your guidance is directed by these core principles:
 
 Apply these principles when evaluating whether complex patterns, or advanced optimizations are truly needed or if simpler solutions would suffice.
 
-## Code Style Rules
+## Coding Standards
 
-- **Unused Arguments**: Prefix unused arguments in functions and methods with an underscore (`_`).
-  - Example: `def handler(event, _context):` instead of `def handler(event, context):`.
-  - This rule is enforced by the linter (ruff) via the `ARG` check.
-- **Type Annotations in Tests**: Add explicit return annotations for test functions and fixtures (`-> None` for tests, concrete types for fixtures like `WorkflowContext`/`Issue`).
-- **CLI Option Hygiene**: For new/updated Typer options, keep `show_default=True` where appropriate and normalize/validate string inputs (reject whitespace-only values, pass trimmed values downstream).
-- **Workflow Dependency Declarations**: Keep step registry comments and `dependencies=[...]` declarations aligned so dependency requirements are explicit and accurate.
-- **Test Isolation**: When a test path can emit comments or trigger external integrations, patch those external helpers in the step module to avoid network/database side effects.
+Follow `CODING_STANDARDS.md` for repository-wide code style and testing standards.
 
 ## Development Commands
 

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,11 @@
+# Coding Standards
+
+## Code Style Rules
+
+- **Unused Arguments**: Prefix unused arguments in functions and methods with an underscore (`_`).
+  - Example: `def handler(event, _context):` instead of `def handler(event, context):`.
+  - This rule is enforced by the linter (ruff) via the `ARG` check.
+- **Type Annotations in Tests**: Add explicit return annotations for test functions and fixtures (`-> None` for tests, concrete types for fixtures like `WorkflowContext`/`Issue`).
+- **CLI Option Hygiene**: For new/updated Typer options, keep `show_default=True` where appropriate and normalize/validate string inputs (reject whitespace-only values, pass trimmed values downstream).
+- **Workflow Dependency Declarations**: Keep step registry comments and `dependencies=[...]` declarations aligned so dependency requirements are explicit and accurate.
+- **Test Isolation**: When a test path can emit comments or trigger external integrations, patch those external helpers in the step module to avoid network/database side effects.


### PR DESCRIPTION
## Description

This change centralizes repository coding rules in a dedicated `CODING_STANDARDS.md` document and updates `AGENTS.md` to reference that file instead of duplicating the full style section. The motivation is to keep standards in one authoritative place and reduce drift between agent guidance and coding policy. No runtime dependencies are introduced.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## What Changed

- Added `CODING_STANDARDS.md` as the canonical home for code style and testing standards.
- Moved the prior code style rules from `AGENTS.md` into `CODING_STANDARDS.md`.
- Replaced the full rules section in `AGENTS.md` with a concise pointer to `CODING_STANDARDS.md`.

## How to Test

- [x] Run `git diff HEAD~1` and confirm `AGENTS.md` now points to `CODING_STANDARDS.md`.
- [x] Open `CODING_STANDARDS.md` and verify it contains the moved rules (including test return type annotations).
- [x] Run `git show --name-only --oneline -1` and confirm only docs files changed.


@coderabbitai ignore
