### PR TITLE
fix(git-checkout-step): remove stale get_repo_path mock from test

### DIFF
--- a/src/rouge/core/workflow/steps/git_checkout_step.py
+++ b/src/rouge/core/workflow/steps/git_checkout_step.py
@@ -73,7 +73,6 @@ class GitCheckoutStep(WorkflowStep):
     from the remote with tracking (git checkout -t origin/<branch>).
 
     Environment Variables:
-        REPO_PATH: The repository path (defaults to current directory)
         ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS: Set to "true" to allow destructive git
             operations (git reset --hard, git clean -fd) for cleaning dirty
             working trees. Required for non-worker environments to prevent

--- a/tests/test_git_checkout_step.py
+++ b/tests/test_git_checkout_step.py
@@ -149,11 +149,10 @@ def test_checkout_step_loads_issue_from_fetch_patch_artifact(tmp_path) -> None:
 # === context.issue path (source-agnostic) ===
 
 
-@patch("rouge.core.workflow.steps.git_checkout_step.get_repo_path")
 @patch("rouge.core.workflow.steps.git_checkout_step.subprocess.run")
 @patch.dict("os.environ", {"ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS": "false"}, clear=False)
 def test_checkout_step_uses_context_issue_when_no_artifact(
-    mock_subprocess, mock_get_repo_path, tmp_path
+    mock_subprocess, tmp_path
 ) -> None:
     """Step uses context.issue directly when no FetchPatchArtifact is present.
 
@@ -161,8 +160,6 @@ def test_checkout_step_uses_context_issue_when_no_artifact(
     without requiring a FetchPatchArtifact on disk, and that the branch
     from context.issue is passed to git checkout.
     """
-    mock_get_repo_path.return_value = "/repo"
-
     mock_fetch = Mock(returncode=0, stdout="", stderr="")
     mock_checkout = Mock(returncode=0, stdout="", stderr="")
     mock_pull = Mock(returncode=0, stdout="", stderr="")
@@ -172,7 +169,7 @@ def test_checkout_step_uses_context_issue_when_no_artifact(
     issue = _make_issue(branch="context-issue-branch")
     store = ArtifactStore(workflow_id="test-ctx", base_path=tmp_path)
     # Intentionally do NOT write a FetchPatchArtifact to the store.
-    ctx = WorkflowContext(issue_id=1, adw_id="test-ctx", issue=issue, artifact_store=store)
+    ctx = WorkflowContext(issue_id=1, adw_id="test-ctx", issue=issue, artifact_store=store, repo_paths=["/repo"])
 
     step = GitCheckoutStep()
     result = step.run(ctx)


### PR DESCRIPTION
## Description

Fixes a failing test in `test_git_checkout_step.py` caused by a stale reference to a `get_repo_path` function that was removed when `repo_paths` moved to `WorkflowContext` (ce8727d). The test was patching a function that no longer exists, causing an `AttributeError` at collection time.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## What Changed

- Removed `@patch("...get_repo_path")` decorator and `mock_get_repo_path` parameter from `test_checkout_step_uses_context_issue_when_no_artifact`
- Added `repo_paths=["/repo"]` directly to the `WorkflowContext` constructor call to match the current implementation
- Removed stale `REPO_PATH` env var entry from `GitCheckoutStep` class docstring

## How to Test

- [ ] Run `uv run pytest tests/test_git_checkout_step.py -v` — all 33 tests should pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated environment variable documentation from Git checkout workflow step.

* **Changes**
  * Updated workflow context initialization to accept explicit repository paths, replacing previous path derivation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->