### PR TITLE
fix(code-review-step): use checked-out repos from GitCheckoutArtifact

### DIFF
--- a/src/rouge/core/workflow/artifacts.py
+++ b/src/rouge/core/workflow/artifacts.py
@@ -299,12 +299,17 @@ class GitCheckoutArtifact(Artifact):
 
     Attributes:
         branch: The name of the branch that was checked out
+        checked_out_repos: List of repo paths where the branch was successfully checked out
     """
 
     artifact_type: Literal["git-checkout"] = "git-checkout"
     branch: str = Field(
         description=("The name of the git branch that was checked out for the workflow"),
         min_length=1,
+    )
+    checked_out_repos: List[str] = Field(
+        default_factory=list,
+        description="Repo paths where the branch was successfully checked out",
     )
 
 

--- a/src/rouge/core/workflow/steps/code_review_step.py
+++ b/src/rouge/core/workflow/steps/code_review_step.py
@@ -6,7 +6,7 @@ import subprocess
 
 from rouge.core.models import CommentPayload
 from rouge.core.notifications.comments import emit_comment_from_payload
-from rouge.core.workflow.artifacts import CodeReviewArtifact, PlanArtifact
+from rouge.core.workflow.artifacts import CodeReviewArtifact, GitCheckoutArtifact, PlanArtifact
 from rouge.core.workflow.step_base import StepInputError, WorkflowContext, WorkflowStep
 from rouge.core.workflow.types import ReviewData, StepResult
 
@@ -170,6 +170,19 @@ class CodeReviewStep(WorkflowStep):
             return StepResult.fail(f"No plan data available: {e}")
 
         repo_path = context.repo_paths[0]
+
+        # For codereview/patch workflows, prefer repos where the branch was
+        # actually checked out (stored in GitCheckoutArtifact). Fall back to
+        # repo_paths[0] when the artifact is absent (e.g. main workflow).
+        checkout_artifact = context.load_optional_artifact(
+            "git_checkout",
+            "git-checkout",
+            GitCheckoutArtifact,
+            lambda a: a,
+        )
+        if checkout_artifact is not None and checkout_artifact.checked_out_repos:
+            repo_path = checkout_artifact.checked_out_repos[0]
+            logger.debug("Using checked-out repo from GitCheckoutArtifact: %s", repo_path)
 
         # Only codereview workflows should pass a base commit to CodeRabbit.
         # Main/patch workflows use plan_data.plan for markdown content, not a git SHA.

--- a/src/rouge/core/workflow/steps/git_checkout_step.py
+++ b/src/rouge/core/workflow/steps/git_checkout_step.py
@@ -301,6 +301,7 @@ class GitCheckoutStep(WorkflowStep):
                 artifact = GitCheckoutArtifact(
                     workflow_id=context.adw_id,
                     branch=branch,
+                    checked_out_repos=checked_out_repos,
                 )
                 context.artifact_store.write_artifact(artifact)
                 logger.debug("Saved git_checkout artifact for workflow %s", context.adw_id)

--- a/tests/test_code_review_step.py
+++ b/tests/test_code_review_step.py
@@ -20,6 +20,7 @@ def mock_context():
     context.data = {}
     context.artifact_store = Mock()
     context.repo_paths = ["/path/to/repo"]
+    context.load_optional_artifact.return_value = None
     return context
 
 


### PR DESCRIPTION
## Description

In multi-repo environments (`REPO_PATH=ws2-api,ws2-mobile`), `CodeReviewStep` was always running CodeRabbit against `repo_paths[0]`. When the branch is only present in a downstream repo (e.g. `ws2-mobile` but not `ws2-api`), this caused a `CodeRabbit config not found` failure.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## What Changed

- `GitCheckoutArtifact` gains a `checked_out_repos: List[str]` field listing repos where the branch was actually checked out
- `GitCheckoutStep` populates `checked_out_repos` when saving the artifact
- `CodeReviewStep` loads `GitCheckoutArtifact` as an optional artifact and uses `checked_out_repos[0]` when available, falling back to `repo_paths[0]` for workflows without a checkout step (e.g. main workflow)
- `test_code_review_step.py`: set `load_optional_artifact.return_value = None` on the shared `mock_context` fixture

## How to Test

- [ ] Run `rouge-worker` in a multi-repo environment where the branch only exists in one repo — CodeRabbit should run against the correct repo
- [ ] Run `uv run pytest tests/ -q` — all tests pass