### PR TITLE
Add JSON schema for structured code review summary output

### DIFF
--- a/src/rouge/core/workflow/steps/code_review_step.py
+++ b/src/rouge/core/workflow/steps/code_review_step.py
@@ -1,5 +1,6 @@
 """Review generation step implementation."""
 
+import json
 import logging
 import os
 import subprocess
@@ -17,6 +18,16 @@ logger = logging.getLogger(__name__)
 
 # Module-level constant for step name used in rerun_from references
 CODE_REVIEW_STEP_NAME = "Generating CodeRabbit review"
+
+# JSON schema for code review summary structured output
+CODE_REVIEW_SUMMARY_JSON_SCHEMA = """{
+  "type": "object",
+  "properties": {
+    "output": { "type": "string", "const": "code-review-summary" },
+    "summary": { "type": "string", "minLength": 1 }
+  },
+  "required": ["output", "summary"]
+}"""
 
 
 def is_clean_review(review_text: str) -> bool:
@@ -192,8 +203,9 @@ class CodeReviewStep(WorkflowStep):
                 adw_id=adw_id or "",
                 issue_id=issue_id,
                 model="sonnet",
+                json_schema=CODE_REVIEW_SUMMARY_JSON_SCHEMA,
             )
-            summary_response = execute_template(request, require_json=False)
+            summary_response = execute_template(request, require_json=True)
         except Exception as e:
             logger.error("Failed to call /adw-code-review-summary: %s", e, exc_info=True)
             return
@@ -202,7 +214,16 @@ class CodeReviewStep(WorkflowStep):
             logger.warning("Failed to generate review summary, skipping PR comment")
             return
 
-        summary = summary_response.output.strip()
+        # Parse JSON output to extract summary field
+        try:
+            parsed_output = json.loads(summary_response.output)
+            summary = parsed_output.get("summary", "").strip()
+            if not summary:
+                logger.warning("Empty summary field in JSON response, skipping PR comment")
+                return
+        except (json.JSONDecodeError, TypeError, AttributeError) as e:
+            logger.error("Failed to parse summary JSON response: %s", e, exc_info=True)
+            return
         body = (
             f"{summary}\n\n<details><summary>Full review</summary>" f"\n\n{review_text}\n</details>"
         )

--- a/tests/test_code_review_step.py
+++ b/tests/test_code_review_step.py
@@ -486,8 +486,10 @@ class TestCodeReviewStepPostReviewSummary:
         """Test _post_review_summary_to_pr calls _post_comment_to_pr on success."""
         from rouge.core.agents.claude import ClaudeAgentPromptResponse
 
+        # Return JSON output with summary field (Phase 3 updated code to parse JSON)
+        json_output = '{"output": "code-review-summary", "summary": "Two critical issues found."}'
         mock_execute_template.return_value = ClaudeAgentPromptResponse(
-            output="Two critical issues found.",
+            output=json_output,
             success=True,
             session_id="sess-summary",
         )
@@ -537,6 +539,78 @@ class TestCodeReviewStepPostReviewSummary:
             adw_id="adw-1",
             issue_id=10,
         )
+
+    @patch.object(CodeReviewStep, "_post_comment_to_pr")
+    @patch("rouge.core.workflow.steps.code_review_step.execute_template")
+    def test_post_review_summary_to_pr_with_structured_output(
+        self, mock_execute_template, mock_post_comment
+    ) -> None:
+        """Test _post_review_summary_to_pr uses JSON schema and parses structured output."""
+        from rouge.core.agents.claude import ClaudeAgentPromptResponse
+        from rouge.core.workflow.steps.code_review_step import CODE_REVIEW_SUMMARY_JSON_SCHEMA
+
+        # Mock execute_template to return JSON output with summary field
+        json_output = '{"output": "code-review-summary", "summary": "Two critical issues found."}'
+        mock_execute_template.return_value = ClaudeAgentPromptResponse(
+            output=json_output,
+            success=True,
+            session_id="sess-summary",
+        )
+
+        step = CodeReviewStep()
+        step._post_review_summary_to_pr(
+            review_text="File: src/app.py\nLine 10: Issue.",
+            pr_number=42,
+            platform="github",
+            repo_path="/repo",
+            adw_id="adw-1",
+            issue_id=10,
+        )
+
+        # Verify execute_template was called with json_schema and require_json=True
+        mock_execute_template.assert_called_once()
+        request = mock_execute_template.call_args[0][0]
+        assert request.json_schema == CODE_REVIEW_SUMMARY_JSON_SCHEMA
+        assert mock_execute_template.call_args[1]["require_json"] is True
+
+        # Verify _post_comment_to_pr was called with the correctly extracted summary
+        mock_post_comment.assert_called_once()
+        call_kwargs = mock_post_comment.call_args.kwargs
+        assert "Two critical issues found." in call_kwargs["body"]
+        assert call_kwargs["pr_number"] == 42
+        assert call_kwargs["platform_lower"] == "github"
+
+    @patch.object(CodeReviewStep, "_post_comment_to_pr")
+    @patch("rouge.core.workflow.steps.code_review_step.execute_template")
+    def test_post_review_summary_to_pr_handles_json_parse_error(
+        self, mock_execute_template, mock_post_comment
+    ) -> None:
+        """Test _post_review_summary_to_pr handles malformed JSON and returns early."""
+        from rouge.core.agents.claude import ClaudeAgentPromptResponse
+
+        # Mock execute_template to return malformed JSON
+        mock_execute_template.return_value = ClaudeAgentPromptResponse(
+            output='{invalid json syntax',
+            success=True,
+            session_id="sess-summary",
+        )
+
+        step = CodeReviewStep()
+        # Should not raise; error is logged and method returns early
+        step._post_review_summary_to_pr(
+            review_text="File: src/app.py\nLine 10: Issue.",
+            pr_number=42,
+            platform="github",
+            repo_path="/repo",
+            adw_id="adw-1",
+            issue_id=10,
+        )
+
+        # Verify execute_template was called
+        mock_execute_template.assert_called_once()
+
+        # Verify _post_comment_to_pr was NOT called due to JSON parse error
+        mock_post_comment.assert_not_called()
 
 
 class TestCodeReviewStepPostCommentToPr:


### PR DESCRIPTION
## Description

This change adds structured JSON output support to the code review summary generation in the CodeReviewStep workflow. Previously, the review summary was returned as plain text, which could be inconsistent or difficult to parse. Now, the summary skill returns JSON with an "output" and "summary" field, ensuring consistent, machine-readable responses.

The change includes:
- A JSON schema definition for the code review summary output format
- Updated execute_template call to use require_json=True with the schema
- JSON parsing logic to extract the summary field before posting to PR
- Error handling for JSON decode failures with logging and early return

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Added CODE_REVIEW_SUMMARY_JSON_SCHEMA constant with JSON schema definition
- Updated _post_review_summary_to_pr to call execute_template with json_schema parameter and require_json=True
- Added JSON parsing logic to extract summary field from structured output
- Added error handling for JSON decode failures (JSONDecodeError, TypeError, AttributeError)
- Updated test to return JSON output matching the new schema format
- Added test_post_review_summary_to_pr_with_structured_output to verify JSON schema usage
- Added test_post_review_summary_to_pr_handles_json_parse_error to verify error handling

## How to Test

- [ ] Run tests: `uv run pytest tests/test_code_review_step.py::TestCodeReviewStepPostReviewSummary -v`
- [ ] Verify new tests pass: test_post_review_summary_to_pr_with_structured_output and test_post_review_summary_to_pr_handles_json_parse_error
- [ ] Run full test suite: `uv run pytest`
- [ ] Manually test by running rouge-adw on an issue with PR to verify review summary is posted correctly