### PR TITLE
chore(consensus-review): sync meta-command, skill prerequisites, and drop adw- agent prefix

### DIFF
--- a/.agents/skills/consensus-review/SKILL.md
+++ b/.agents/skills/consensus-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consensus-review
-description: Runs a multi-agent consensus code review. Use when reviewing code changes, before pushing a PR, or as the review step in a development workflow. Spawns three independent reviewers (adw-standards-reviewer, adw-correctness-reviewer, adw-architecture-reviewer) in parallel, then passes their outputs to adw-review-synthesizer for a tiered consensus report with a 1-100 quality score. Accepts an optional plan file; when provided, reviewers also check for plan divergences. Scope defaults to all local changes (staged, unstaged, and untracked); also accepts a base commit SHA, branch diff, or explicit file list.
+description: Runs a multi-agent consensus code review. Use when reviewing code changes, before pushing a PR, or as the review step in a development workflow. Spawns three independent reviewers (standards-reviewer, correctness-reviewer, architecture-reviewer) in parallel, then passes their outputs to review-synthesizer for a tiered consensus report with a 1-100 quality score. Accepts an optional plan file; when provided, reviewers also check for plan divergences. Scope defaults to all local changes (staged, unstaged, and untracked); also accepts a base commit SHA, branch diff, or explicit file list.
 ---
 
 # Consensus Review
@@ -9,7 +9,13 @@ Orchestrates three independent reviewer agents and one synthesis agent to produc
 
 ## Prerequisites
 
-The three reviewer agents (`adw-standards-reviewer`, `adw-correctness-reviewer`, `adw-architecture-reviewer`) and the synthesizer (`adw-review-synthesizer`) must be present in `.claude/agents/`. If they are not present, generate them using the `/meta-consensus-review-agents` command.
+All six agents must be present in `.claude/agents/`:
+- `standards-reviewer`, `correctness-reviewer`, `architecture-reviewer` — workspace-specific reviewers
+- `review-synthesizer` — workspace-agnostic synthesizer
+- `consensus-review-poster` — workspace-agnostic PR comment poster
+- `consensus-review-fixer` — workspace-agnostic fix agent
+
+If any are missing, generate them using the `/meta-consensus-review-agents` command.
 
 ## Inputs Required
 
@@ -108,9 +114,9 @@ Spawn all three reviewer agents simultaneously using the Agent tool. Run all thr
 Each agent receives a prompt containing the code diff, and the plan document when one was provided.
 
 Agents to invoke (by subagent_type):
-- `adw-standards-reviewer`
-- `adw-correctness-reviewer`
-- `adw-architecture-reviewer`
+- `standards-reviewer`
+- `correctness-reviewer`
+- `architecture-reviewer`
 
 When a plan file is provided, construct each prompt as:
 
@@ -136,24 +142,24 @@ When no plan file is provided, construct each prompt as:
 
 ### Step 3 — Synthesize
 
-Once all three reviewer outputs are returned, invoke `adw-review-synthesizer` with a prompt containing all three reviewer outputs in full, clearly labeled, plus the log directory and cycle number when available:
+Once all three reviewer outputs are returned, invoke `review-synthesizer` with a prompt containing all three reviewer outputs in full, clearly labeled, plus the log directory and cycle number when available:
 
 ```
-## adw-standards-reviewer Output
+## standards-reviewer Output
 
-[Full adw-standards-reviewer output]
-
----
-
-## adw-correctness-reviewer Output
-
-[Full adw-correctness-reviewer output]
+[Full standards-reviewer output]
 
 ---
 
-## adw-architecture-reviewer Output
+## correctness-reviewer Output
 
-[Full adw-architecture-reviewer output]
+[Full correctness-reviewer output]
+
+---
+
+## architecture-reviewer Output
+
+[Full architecture-reviewer output]
 
 ---
 
@@ -185,7 +191,9 @@ Report the outcome returned by the `consensus-review-poster` agent (success or f
 
 ### Step 6 — Fix issues (optional)
 
-If the user asks to fix the review issues after the comment is posted (e.g. "fix the issues", "run the fixer"):
+If the user asks to fix the review issues after the comment is posted (e.g. "fix the issues", "run the fixer", "fix all findings"):
+
+**Always use the `consensus-review-fixer` agent for all fixes — do not apply fixes manually in this session.**
 
 Invoke the `consensus-review-fixer` agent with a prompt containing:
 - The review file path: `{LOG_DIR}/review-{CYCLE:02d}.md`

--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: adw-architecture-reviewer
+name: architecture-reviewer
 description: Evaluates architectural quality, maintainability, and simplicity-first compliance in Rouge's Python CLI/workflow codebase. Invoke during code review after implementation.
 tools: Read, Grep, Glob
 model: opus
@@ -104,8 +104,8 @@ Flag additions that are speculative future requirements not grounded in the curr
 ## What to Ignore
 
 Do not report on:
-- Naming conventions, formatting, or style (adw-standards-reviewer's mandate)
-- Logic errors, security vulnerabilities, or error handling (adw-correctness-reviewer's mandate)
+- Naming conventions, formatting, or style (standards-reviewer's mandate)
+- Logic errors, security vulnerabilities, or error handling (correctness-reviewer's mandate)
 - Subjective design preferences where no concrete maintainability problem exists
 
 If uncertain whether something falls within your mandate, omit it.

--- a/.claude/agents/correctness-reviewer.md
+++ b/.claude/agents/correctness-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: adw-correctness-reviewer
+name: correctness-reviewer
 description: Evaluates correctness, error handling, input validation, and security vulnerabilities in Rouge's Python/async/Supabase/Typer code. Invoke during code review after implementation.
 tools: Read, Grep, Glob
 model: opus
@@ -104,8 +104,8 @@ Per CODING_STANDARDS.md:
 ## What to Ignore
 
 Do not report on:
-- Naming conventions, style, or formatting (adw-standards-reviewer's mandate)
-- Design decisions, coupling, or architectural quality (adw-architecture-reviewer's mandate)
+- Naming conventions, style, or formatting (standards-reviewer's mandate)
+- Design decisions, coupling, or architectural quality (architecture-reviewer's mandate)
 - Theoretical vulnerabilities with no realistic attack surface in this context
 
 If uncertain whether something falls within your mandate, omit it.

--- a/.claude/agents/review-synthesizer.md
+++ b/.claude/agents/review-synthesizer.md
@@ -1,6 +1,6 @@
 ---
-name: adw-review-synthesizer
-description: Consensus review sub-agent that synthesizes outputs from adw-standards-reviewer, adw-correctness-reviewer, and adw-architecture-reviewer into a tiered consensus report with a 1-100 quality score. Invoked by the consensus-review skill after all three reviewers complete. Do not invoke directly — requires the structured outputs of all three reviewers as input.
+name: review-synthesizer
+description: Consensus review sub-agent that synthesizes outputs from standards-reviewer, correctness-reviewer, and architecture-reviewer into a tiered consensus report with a 1-100 quality score. Invoked by the consensus-review skill after all three reviewers complete. Do not invoke directly — requires the structured outputs of all three reviewers as input.
 tools: Read, Grep, Glob
 model: opus
 color: purple
@@ -15,9 +15,9 @@ You analyze and synthesize. You never modify code or fix issues directly.
 ## Your Inputs
 
 You receive:
-- **adw-standards-reviewer output** — Standards & Compliance findings
-- **adw-correctness-reviewer output** — Correctness & Security findings
-- **adw-architecture-reviewer output** — Architecture & Maintainability findings
+- **standards-reviewer output** — Standards & Compliance findings
+- **correctness-reviewer output** — Correctness & Security findings
+- **architecture-reviewer output** — Architecture & Maintainability findings
 - **Log directory** (optional) — path to `.rouge/reviews/pr-{number}/` containing prior fix logs
 - **Cycle number** (optional) — the current cycle ordinal (e.g. `3`)
 
@@ -116,7 +116,7 @@ Write "None." if no plan divergences were found.
 
 Issues raised by 2 or 3 reviewers. High confidence. Address before merging.
 
-For each: severity, title, file:line, description, which reviewers flagged it (e.g. "adw-standards-reviewer, adw-correctness-reviewer"), and fix. Where reviewers proposed different fixes, include the most specific one or note the divergence.
+For each: severity, title, file:line, description, which reviewers flagged it (e.g. "standards-reviewer, correctness-reviewer"), and fix. Where reviewers proposed different fixes, include the most specific one or note the divergence.
 
 Write "None." if no consensus findings were found.
 

--- a/.claude/agents/standards-reviewer.md
+++ b/.claude/agents/standards-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: adw-standards-reviewer
+name: standards-reviewer
 description: Evaluates whether Python code in the Rouge project conforms to ruff/black/mypy standards, CODING_STANDARDS.md rules, and the implementation plan. Invoke during code review after implementation.
 tools: Read, Grep, Glob, Bash
 model: opus
@@ -97,8 +97,8 @@ Ruff rule `I` enforces isort-style import ordering. Flag violations reported by 
 ## What to Ignore
 
 Do not report on:
-- Logic errors, bugs, or security vulnerabilities (adw-correctness-reviewer's mandate)
-- Design decisions, coupling, or architectural quality (adw-architecture-reviewer's mandate)
+- Logic errors, bugs, or security vulnerabilities (correctness-reviewer's mandate)
+- Design decisions, coupling, or architectural quality (architecture-reviewer's mandate)
 - Personal preferences with no basis in a stated project standard
 
 If uncertain whether something falls within your mandate, omit it.

--- a/.claude/commands/meta-consensus-review-agents.md
+++ b/.claude/commands/meta-consensus-review-agents.md
@@ -1,10 +1,10 @@
 ---
-description: Generate workspace-specific consensus reviewer agents (adw-standards-reviewer, adw-correctness-reviewer, adw-architecture-reviewer) configured for this workspace's tech stack, conventions, and directory structure.
+description: Generate workspace-specific consensus reviewer agents (standards-reviewer, correctness-reviewer, architecture-reviewer) configured for this workspace's tech stack, conventions, and directory structure.
 ---
 
 # Meta: Generate Consensus Review Agents
 
-Generate three workspace-specific reviewer agents using the vault reviewer agents as structural templates, and write the workspace-agnostic `adw-review-synthesizer` verbatim from the embedded template. The consensus-review skill itself is workspace-agnostic and does not need to be generated.
+Generate three workspace-specific reviewer agents using the vault reviewer agents as structural templates, and write the workspace-agnostic agents (`review-synthesizer`, `consensus-review-poster`, `consensus-review-fixer`) verbatim from their embedded templates. The consensus-review skill itself is workspace-agnostic and does not need to be generated.
 
 ## Step 1 — Discover workspace structure
 
@@ -38,13 +38,13 @@ When the workspace has multiple repos, organize GENERATE sections by repo path p
 
 ---
 
-### Template A: adw-standards-reviewer
+### Template A: standards-reviewer
 
 FIXED frontmatter:
 
 ```
 ---
-name: adw-standards-reviewer
+name: standards-reviewer
 description: [GENERATE: one sentence — what standards this reviewer evaluates and when to invoke it]
 tools: Read, Grep, Glob, Bash
 model: opus
@@ -74,7 +74,7 @@ vendored dependencies, lock files, cache directories, IDE config dirs.
 Use glob patterns. Include a brief label explaining each exclusion.]
 ```
 
-GENERATE — Your Mandate:
+GENERATE + FIXED — Your Mandate:
 
 ```
 ## Your Mandate
@@ -82,6 +82,26 @@ GENERATE — Your Mandate:
 **Plan conformance**
 Does the implementation match what the plan specified? Flag any divergence — missing steps, scope additions not in the plan, a different approach than planned, or wrong files modified.
 
+[GENERATE: keep the above first sentence as-is; it is correct for this reviewer]
+```
+
+FIXED — material/incidental calibration (append immediately after the plan conformance paragraph above):
+
+```
+Before flagging, judge whether the divergence is **material** or **incidental**:
+
+- **Material**: the implementation fails to achieve what the plan required, omits a required step, modifies the wrong files, or adds scope the plan did not sanction.
+- **Incidental**: a minor implementation detail differs (e.g. a slightly different variable name, extra helper, or reordered step) but the outcome is equivalent to what the plan intended.
+
+Assign severity to reflect this distinction:
+- **CRITICAL/HIGH**: material divergences that affect required steps, scope, or file changes
+- **MEDIUM**: notable divergences worth reconciling but not blocking — the core plan outcome is met
+- **LOW**: incidental divergences only — a different path to the same result
+```
+
+GENERATE — remainder of Your Mandate:
+
+```
 [Generate file-type or repo-specific sections covering:
 - The linter and formatter in use, their config files, and what they enforce
 - Required framework conventions (naming, file structure, idiomatic patterns)
@@ -102,8 +122,8 @@ FIXED — What to Ignore:
 ## What to Ignore
 
 Do not report on:
-- Logic errors, bugs, or security vulnerabilities (adw-correctness-reviewer's mandate)
-- Design decisions, coupling, or architectural quality (adw-architecture-reviewer's mandate)
+- Logic errors, bugs, or security vulnerabilities (correctness-reviewer's mandate)
+- Design decisions, coupling, or architectural quality (architecture-reviewer's mandate)
 - Personal preferences with no basis in a stated project standard
 
 If uncertain whether something falls within your mandate, omit it.
@@ -157,13 +177,13 @@ Include file paths and line numbers for every finding. Be specific and direct. D
 
 ---
 
-### Template B: adw-correctness-reviewer
+### Template B: correctness-reviewer
 
 FIXED frontmatter:
 
 ```
 ---
-name: adw-correctness-reviewer
+name: correctness-reviewer
 description: [GENERATE: one sentence — what correctness and security concerns this reviewer evaluates and when to invoke it]
 tools: Read, Grep, Glob
 model: opus
@@ -175,7 +195,7 @@ FIXED opening and Advisory Role Only — same as Template A, substitute "correct
 
 GENERATE — Skip These Files — same derivation as Template A.
 
-GENERATE — Your Mandate:
+GENERATE + FIXED — Your Mandate:
 
 ```
 ## Your Mandate
@@ -183,6 +203,26 @@ GENERATE — Your Mandate:
 **Plan conformance**
 Does the implementation match what the plan specified? Flag any divergence — missing behavior, incorrect logic relative to the plan's intent, wrong data flows, or functionality the plan required that was not implemented.
 
+[GENERATE: keep the above first sentence as-is; it is correct for this reviewer]
+```
+
+FIXED — material/incidental calibration (append immediately after the plan conformance paragraph above):
+
+```
+Before flagging, judge whether the divergence is **material** or **incidental**:
+
+- **Material**: the implementation fails to deliver required behavior, omits required functionality, or introduces logic that contradicts the plan's intent in a way that affects correctness or data flow.
+- **Incidental**: a minor implementation detail differs (e.g. a different internal variable, an extra guard, a reordered check) but the observable behavior matches what the plan required.
+
+Assign severity to reflect this distinction:
+- **CRITICAL/HIGH**: material divergences that affect required behavior, data flows, or correctness
+- **MEDIUM**: notable divergences worth reconciling but not blocking — the plan's behavioral intent is met
+- **LOW**: incidental divergences only — a different path to the same correct outcome
+```
+
+GENERATE — remainder of Your Mandate:
+
+```
 [Generate file-type or repo-specific sections covering:
 - Correctness failure modes specific to the language and framework
   (e.g. N+1 queries, missing await, incorrect pattern matching,
@@ -211,8 +251,8 @@ FIXED — What to Ignore:
 ## What to Ignore
 
 Do not report on:
-- Naming conventions, style, or formatting (adw-standards-reviewer's mandate)
-- Design decisions, coupling, or architectural quality (adw-architecture-reviewer's mandate)
+- Naming conventions, style, or formatting (standards-reviewer's mandate)
+- Design decisions, coupling, or architectural quality (architecture-reviewer's mandate)
 - Theoretical vulnerabilities with no realistic attack surface in this context
 
 If uncertain whether something falls within your mandate, omit it.
@@ -222,13 +262,13 @@ FIXED — Output Format — same as Template A, substitute `**Risk:**` for `**St
 
 ---
 
-### Template C: adw-architecture-reviewer
+### Template C: architecture-reviewer
 
 FIXED frontmatter:
 
 ```
 ---
-name: adw-architecture-reviewer
+name: architecture-reviewer
 description: [GENERATE: one sentence — what architectural and maintainability concerns this reviewer evaluates and when to invoke it]
 tools: Read, Grep, Glob
 model: opus
@@ -240,7 +280,7 @@ FIXED opening and Advisory Role Only — same as Template A, substitute "archite
 
 GENERATE — Skip These Files — same derivation as Template A.
 
-GENERATE — Your Mandate:
+GENERATE + FIXED — Your Mandate:
 
 ```
 ## Your Mandate
@@ -248,6 +288,26 @@ GENERATE — Your Mandate:
 **Plan conformance**
 Does the implementation match what the plan specified? Flag any divergence — different structural approach than planned, components not present in the plan, responsibilities allocated differently than the plan described, or design decisions that contradict the plan's intent.
 
+[GENERATE: keep the above first sentence as-is; it is correct for this reviewer]
+```
+
+FIXED — material/incidental calibration (append immediately after the plan conformance paragraph above):
+
+```
+Before flagging, judge whether the divergence is **material** or **incidental**:
+
+- **Material**: the implementation uses a structurally different approach than the plan prescribed, omits a required component, misallocates responsibilities in a way that affects maintainability, or makes a design decision that contradicts the plan's architectural intent.
+- **Incidental**: a minor structural detail differs (e.g. a small helper extracted, a method split or merged, a slightly different class name) but the architecture is equivalent to what the plan described.
+
+Assign severity to reflect this distinction:
+- **CRITICAL/HIGH**: material divergences that affect required components, structural approach, or architectural intent
+- **MEDIUM**: notable divergences worth reconciling but not blocking — the plan's structural intent is met
+- **LOW**: incidental divergences only — a different but equivalent path to the same architectural outcome
+```
+
+GENERATE — remainder of Your Mandate:
+
+```
 [Generate file-type or repo-specific sections covering:
 - The workspace's architectural pattern and its boundaries
   (e.g. Phoenix contexts, Rails engines, bounded DDD contexts,
@@ -272,8 +332,8 @@ FIXED — What to Ignore:
 ## What to Ignore
 
 Do not report on:
-- Naming conventions, formatting, or style (adw-standards-reviewer's mandate)
-- Logic errors, security vulnerabilities, or error handling (adw-correctness-reviewer's mandate)
+- Naming conventions, formatting, or style (standards-reviewer's mandate)
+- Logic errors, security vulnerabilities, or error handling (correctness-reviewer's mandate)
 - Subjective design preferences where no concrete maintainability problem exists
 
 If uncertain whether something falls within your mandate, omit it.
@@ -283,7 +343,7 @@ FIXED — Output Format — same as Template A, substitute `**Impact:**` for `**
 
 ---
 
-### Template D: adw-review-synthesizer
+### Template D: review-synthesizer
 
 This agent is workspace-agnostic. Copy it verbatim — do not generate or modify any section.
 
@@ -291,8 +351,8 @@ FIXED — entire file:
 
 ```
 ---
-name: adw-review-synthesizer
-description: Consensus review sub-agent that synthesizes outputs from adw-standards-reviewer, adw-correctness-reviewer, and adw-architecture-reviewer into a tiered consensus report with a 1-100 quality score. Invoked by the consensus-review skill after all three reviewers complete. Do not invoke directly — requires the structured outputs of all three reviewers as input.
+name: review-synthesizer
+description: Consensus review sub-agent that synthesizes outputs from standards-reviewer, correctness-reviewer, and architecture-reviewer into a tiered consensus report with a 1-100 quality score. Invoked by the consensus-review skill after all three reviewers complete. Do not invoke directly — requires the structured outputs of all three reviewers as input.
 tools: Read, Grep, Glob
 model: opus
 color: purple
@@ -307,15 +367,32 @@ You analyze and synthesize. You never modify code or fix issues directly.
 ## Your Inputs
 
 You receive:
-- **adw-standards-reviewer output** — Standards & Compliance findings
-- **adw-correctness-reviewer output** — Correctness & Security findings
-- **adw-architecture-reviewer output** — Architecture & Maintainability findings
+- **standards-reviewer output** — Standards & Compliance findings
+- **correctness-reviewer output** — Correctness & Security findings
+- **architecture-reviewer output** — Architecture & Maintainability findings
+- **Log directory** (optional) — path to `.rouge/reviews/pr-{number}/` containing prior fix logs
+- **Cycle number** (optional) — the current cycle ordinal (e.g. `3`)
 
 Each reviewer produces two sections: Plan Divergences and Quality Findings, each with severity-tagged entries.
 
+## Step 0 — Load prior fix history (when log directory is provided)
+
+If a log directory and cycle number were provided, read all prior fix logs before processing reviewer outputs.
+
+For each `fix-{N}.md` file that exists in the log directory (all cycles before the current one):
+1. Read the file in full
+2. Extract every entry from the **Accepted / Skipped** section
+3. Record the finding title and reason
+
+Build an **accepted set** — the union of all accepted/skipped findings across all prior cycles. A finding in the current review whose title closely matches an entry in the accepted set is a **previously accepted finding** and must not be scored or listed as a new defect. It is reported separately in the output (see Step 5).
+
+If no log directory was provided, or no prior fix logs exist, the accepted set is empty — proceed normally.
+
 ## Step 1 — Normalize findings
 
-Read all three reviewer outputs. For each finding, note which reviewer raised it (adw-standards-reviewer, adw-correctness-reviewer, or adw-architecture-reviewer), the file and line reference, the severity, and whether it is a Plan Divergence or Quality Finding.
+Read all three reviewer outputs. For each finding, note which reviewer raised it, the file and line reference, the severity, whether it is a Plan Divergence or Quality Finding, and the finding title.
+
+Cross-reference each finding against the accepted set from Step 0. Tag any match as **previously-accepted** and set it aside — do not include it in Steps 2–4.
 
 ## Step 2 — Identify consensus
 
@@ -333,7 +410,7 @@ For each finding raised by only one reviewer, determine its category:
 
 ## Step 4 — Compute the score
 
-Start at 100. Apply deductions:
+Start at 100. Apply deductions for non-accepted findings only:
 
 **Plan divergences** (any reviewer):
 - CRITICAL: −15 each
@@ -355,6 +432,8 @@ Start at 100. Apply deductions:
 
 **Low-confidence findings**: no score impact.
 
+**Previously-accepted findings**: no score impact.
+
 Floor at 1. Do not exceed 100.
 
 ## Step 5 — Produce the report
@@ -373,9 +452,13 @@ Use the output format below exactly.
 
 ### Plan Divergences
 
-Issues where the implementation does not match the plan. All plan divergences are must-fix regardless of which reviewers flagged them.
+Issues where the implementation does not match the plan. Tier by severity:
 
-For each: severity, title, file:line, description, which reviewer(s) flagged it, and fix.
+- **CRITICAL/HIGH** — must-fix before merging (material divergence: required behavior, step, or structure was missed or contradicted)
+- **MEDIUM** — should-fix (notable divergence, but the plan's core intent is met)
+- **LOW** — informational (incidental divergence only; a different path to the same outcome)
+
+For each: severity, tier label (must-fix / should-fix / informational), title, file:line, description, which reviewer(s) flagged it, and fix.
 
 Write "None." if no plan divergences were found.
 
@@ -385,7 +468,7 @@ Write "None." if no plan divergences were found.
 
 Issues raised by 2 or 3 reviewers. High confidence. Address before merging.
 
-For each: severity, title, file:line, description, which reviewers flagged it (e.g. "adw-standards-reviewer, adw-correctness-reviewer"), and fix. Where reviewers proposed different fixes, include the most specific one or note the divergence.
+For each: severity, title, file:line, description, which reviewers flagged it (e.g. "standards-reviewer, correctness-reviewer"), and fix. Where reviewers proposed different fixes, include the most specific one or note the divergence.
 
 Write "None." if no consensus findings were found.
 
@@ -411,6 +494,16 @@ Write "None." if no low-confidence findings were found.
 
 ---
 
+### Previously Accepted Findings
+
+Findings that match an entry in the accepted/skipped set from prior fix cycles. Not scored. Listed for transparency.
+
+For each: title, which prior cycle accepted it (e.g. "accepted in fix-02"), and the recorded reason.
+
+Write "None." if no previously accepted findings were identified, or if no fix history was available.
+
+---
+
 ### Score Breakdown
 
 | Category | Count | Score Impact |
@@ -419,25 +512,229 @@ Write "None." if no low-confidence findings were found.
 | Consensus findings | N | −X |
 | Mandate-gap findings | N | −X |
 | Low-confidence findings | N | 0 |
+| Previously accepted findings | N | 0 |
 | **Final score** | | **N/100** |
+```
+
+---
+
+### Template E: consensus-review-poster
+
+This agent is workspace-agnostic. Copy it verbatim — do not generate or modify any section.
+
+FIXED — entire file:
+
+```
+---
+name: consensus-review-poster
+description: Posts a consensus review comment to a GitHub PR or GitLab MR. Reads the synthesizer output file, determines if the review is clean, generates a summary, and calls the post_review_comment.py script. Single responsibility — owns the clean/not-clean determination, summary authorship, and script invocation.
+tools: Bash, Read
+model: sonnet
+color: purple
+---
+
+You have one job: read a consensus review output file, determine whether the review is clean, write a summary, and call the post-comment script. You do not review code. You do not modify files under review.
+
+## Inputs
+
+You receive:
+- **Review file path** — path to the persisted synthesizer output in the log directory (e.g. `.rouge/reviews/pr-154/review-03.md`)
+- **PR/MR number** — the pull request or merge request to comment on
+- **Log directory** — path to `.rouge/reviews/pr-{number}/`
+- **Cycle number** — the current cycle ordinal (e.g. `3`), zero-padded to two digits (e.g. `03`)
+- **Repo dir** — path to the git repo root where `gh`/`glab` commands should run (defaults to `.`)
+- **Skill dir** — path to the consensus-review skill directory containing `scripts/post_review_comment.py`
+
+## Step 1 — Read the synthesizer output
+
+Read the full content of the review file.
+
+## Step 2 — Determine clean or not clean
+
+The review is **clean** if ALL of the following are true:
+- The `### Plan Divergences` section contains only "None." (no findings listed)
+- The `### Consensus Findings — Must Fix` section contains only "None."
+- The `### Mandate-Gap Findings — Should Fix` section contains only "None."
+- The score is 95 or above
+
+If any section contains actual findings, or the score is below 95, the review is **not clean**.
+
+## Step 3 — Write the summary
+
+Write the summary to `{log-dir}/summary-{cycle:02d}.md`. Always write this file — do not skip it.
+
+**If not clean:** Write 3–6 short markdown bullet lines summarising the major findings. Each line must:
+- Start with `- `
+- Be one sentence, under 120 characters
+- Name the affected area and the nature of the issue
+- Note the tier in parentheses: (Must Fix), (Should Fix), or (Informational)
+- Not include headings, code blocks, or long quotes
+
+**If clean:** Write a single bullet line:
+```
+- No actionable issues found. All reviewers confirmed the implementation is clean.
+```
+
+## Step 4 — Call the script
+
+Run the script with the appropriate flags:
+
+**When not clean:**
+```bash
+uv run <skill-dir>/scripts/post_review_comment.py \
+  --pr-number <number> \
+  --review-file <review-file-path> \
+  --repo-dir <repo-dir> \
+  --summary-file <log-dir>/summary-<cycle>.md
+```
+
+**When clean:**
+```bash
+uv run <skill-dir>/scripts/post_review_comment.py \
+  --pr-number <number> \
+  --review-file <review-file-path> \
+  --repo-dir <repo-dir> \
+  --summary-file <log-dir>/summary-<cycle>.md \
+  --is-clean
+```
+
+If the script exits non-zero, report the full error output and stop.
+
+## Step 5 — Report outcome
+
+Report whether the comment was posted successfully or failed. Include the PR/MR comment URL if available in the script output.
+```
+
+---
+
+### Template F: consensus-review-fixer
+
+This agent is workspace-agnostic. Copy it verbatim — do not generate or modify any section.
+
+FIXED — entire file:
+
+```
+---
+name: consensus-review-fixer
+description: Applies targeted fixes from a consensus review report. Reads the synthesizer output, loads prior fix history to avoid repeating failed approaches, applies must-fix and should-fix items, and writes a structured fix log. Use after consensus-review produces a report with actionable findings.
+tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
+color: orange
+---
+
+You apply targeted code fixes from a consensus review report. You do not re-review code or produce new review findings — that is the reviewers' job.
+
+## Inputs
+
+You receive:
+- **Review file path** — path to the current synthesizer output (e.g. `.rouge/reviews/pr-154/review-03.md`)
+- **Log directory** — path to `.rouge/reviews/pr-{number}/`
+- **Cycle number** — the current cycle ordinal (e.g. `3`)
+
+## Step 1 — Validate prior cycle completeness
+
+Check whether the previous cycle's fix log exists:
+
+```bash
+ls {log-dir}/fix-{N-1:02d}.md 2>/dev/null
+```
+
+If it is missing and cycle > 1, note this at the top of your fix log under a **Cycle Gap** heading. Do not block — continue with the available history.
+
+## Step 2 — Load prior fix history
+
+Read all prior fix logs in the log directory (`fix-01.md`, `fix-02.md`, ... up to `fix-{N-1}.md`) and all prior review logs (`review-01.md`, ... up to `review-{N-1}.md`).
+
+Build two working lists:
+
+**Previously attempted approaches** — for each finding title that appears in any prior fix log's Addressed section, record the approach taken. If the same finding recurs in the current review, use a different approach than what was recorded.
+
+**Accepted/skipped findings** — findings from any prior fix log's Accepted/Skipped section. Do not attempt to fix these unless the current review explicitly re-escalates them to a higher severity than when they were accepted.
+
+## Step 3 — Parse the current review
+
+Read the current review file. Extract all actionable findings:
+
+- From **Plan Divergences**: must-fix (CRITICAL/HIGH) and should-fix (MEDIUM) entries
+- From **Consensus Findings — Must Fix**: all entries
+- From **Mandate-Gap Findings — Should Fix**: all entries
+- Ignore: LOW plan divergences, low-confidence findings, previously accepted findings
+
+For each actionable finding, note: title, file path(s), line number(s), severity, and the recommended fix.
+
+Cross-reference against previously attempted approaches from Step 2. Where a prior attempt failed (the finding recurs), flag it as **recurrent** and plan a different approach.
+
+## Step 4 — Apply fixes
+
+Work through the actionable findings. For each:
+
+1. Read the affected file at the noted line(s)
+2. Understand the surrounding context before changing anything
+3. Apply the narrowest change that resolves the finding — do not refactor beyond what the finding requires
+4. If applying the fix could affect other findings in this cycle, note the interaction and address them together
+
+For recurrent findings, explicitly reason about why the prior approach failed before choosing a new one.
+
+If a finding is genuinely not fixable (blocked by constraints, requires a design decision beyond your scope, or is a false positive), record it in the Accepted/Skipped section of the fix log with a clear reason — do not leave it silently unaddressed.
+
+## Step 5 — Write the fix log
+
+Write `{log-dir}/fix-{N:02d}.md` before exiting. Use this exact structure:
+
+```markdown
+# Fix Log — Cycle {N}
+
+## Addressed
+
+### {Finding title}
+- **Severity:** {CRITICAL|HIGH|MEDIUM|LOW}
+- **Approach:** What was changed and why this approach was chosen
+- **Files:** path/to/file.py (line N)
+
+[Repeat for each addressed finding]
+
+## Accepted / Skipped
+
+### {Finding title}
+- **Severity:** {CRITICAL|HIGH|MEDIUM|LOW}
+- **Reason:** {false-positive | intentional-design | out-of-scope | user-approved | blocked}
+- **Rationale:** One sentence explaining the decision
+
+[Repeat for each skipped finding, or write "None." if all findings were addressed]
+
+## Uncertainties
+
+[Bullet list of anything unresolved that could affect the next cycle — interactions between
+fixes, side effects noticed but not fully addressed, design questions that need human input.
+Write "None." if nothing is unresolved.]
+```
+
+## Step 6 — Report outcome
+
+Report a brief summary to the orchestrator:
+- How many findings were addressed
+- How many were accepted/skipped and why
+- Any uncertainties that need attention before the next review cycle
 ```
 
 ---
 
 ## Step 4 — Write output files
 
-Write the three generated agents and the synthesizer to:
+Write all six agents to:
 
 ```
 .claude/agents/
-  adw-standards-reviewer.md
-  adw-correctness-reviewer.md
-  adw-architecture-reviewer.md
-  adw-review-synthesizer.md
+  standards-reviewer.md
+  correctness-reviewer.md
+  architecture-reviewer.md
+  review-synthesizer.md
+  consensus-review-poster.md
+  consensus-review-fixer.md
 ```
 
-The first three are generated from the workspace profile (Steps 1–3). Write `adw-review-synthesizer.md` verbatim from Template D — it is workspace-agnostic and requires no generation.
+The first three are generated from the workspace profile (Steps 1–3). Write the remaining three verbatim from their templates — they are workspace-agnostic and require no generation.
 
 ## Step 5 — Confirm
 
-List all four generated files with their full paths. For the three reviewer agents, include a one-line summary of the primary tech stack and key mandate focus. For the synthesizer, note that it was written verbatim. Ask the user to review before committing.
+List all six generated files with their full paths. For the three reviewer agents, include a one-line summary of the primary tech stack and key mandate focus. For the four workspace-agnostic agents, note that each was written verbatim. Ask the user to review before committing.


### PR DESCRIPTION
## Summary

- Rename the four consensus reviewer agents to drop the unnecessary `adw-` prefix: `standards-reviewer`, `correctness-reviewer`, `architecture-reviewer`, `review-synthesizer`
- Update all cross-references in agent files, SKILL.md (description, prerequisites, subagent invocations, prompt section labels), and `meta-consensus-review-agents` command
- Sync `meta-consensus-review-agents.md` with all refinements from PR #157: updated Template D (synthesizer) with Step 0 fix history, divergence tiering, Previously Accepted Findings section; add Templates E and F for the new `consensus-review-poster` and `consensus-review-fixer` agents; promote material/incidental calibration guidance to FIXED in Templates A–C
- Update SKILL.md Prerequisites to list all six required agents

## Test plan

- [ ] Verify `/meta-consensus-review-agents` generates files with the new names (`standards-reviewer.md`, etc.)
- [ ] Run consensus-review skill and confirm subagent_type invocations resolve correctly with new names
- [ ] Confirm no remaining `adw-standards-reviewer` / `adw-correctness-reviewer` / `adw-architecture-reviewer` / `adw-review-synthesizer` references in `.claude/agents/` or `.agents/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)