### PR TITLE
DEPRECATED: feat(workflow): scope downstream steps to affected repos only

### DIFF
--- a/src/rouge/core/prompts/templates/code-quality.md
+++ b/src/rouge/core/prompts/templates/code-quality.md
@@ -11,6 +11,12 @@ Discover the available code quality tools in each repository present in the work
 
 ## Instructions
 
+### 0. Scope
+
+If repository paths are provided as arguments (`$ARGUMENTS`), restrict all discovery and tool execution to ONLY those directories. Do not scan for additional repositories outside the provided set.
+
+If no arguments are provided, fall back to the current behavior: discover all repositories by locating `.git` folders.
+
 ### 1. Discover Repositories and Their Tools
 
 Before running anything, survey the working environment:

--- a/src/rouge/core/prompts/templates/code-quality.md
+++ b/src/rouge/core/prompts/templates/code-quality.md
@@ -13,9 +13,13 @@ Discover the available code quality tools in each repository present in the work
 
 ### 0. Scope
 
-If repository paths are provided as arguments (`$ARGUMENTS`), restrict all discovery and tool execution to ONLY those directories. Do not scan for additional repositories outside the provided set.
+## Repositories
 
-If no arguments are provided, fall back to the current behavior: discover all repositories by locating `.git` folders.
+$ARGUMENTS
+
+If repository paths are provided above, restrict all discovery and tool execution to ONLY those directories. Do not scan for additional repositories outside the provided set.
+
+If no paths are provided, fall back to the current behavior: discover all repositories by locating `.git` folders.
 
 ### 1. Discover Repositories and Their Tools
 

--- a/src/rouge/core/workflow/repo_filter.py
+++ b/src/rouge/core/workflow/repo_filter.py
@@ -6,19 +6,21 @@ from typing import Optional, Tuple
 from rouge.core.utils import get_logger
 from rouge.core.workflow.artifacts import ImplementArtifact
 from rouge.core.workflow.step_base import WorkflowContext
+from rouge.core.workflow.step_utils import resolve_base_ref
 from rouge.core.workflow.types import ImplementData
 
 
 def detect_affected_repos(repo_paths: list[str], adw_id: str = "detect") -> list[str]:
     """Detect which repos have commits ahead of the remote default branch.
 
-    Uses ``git diff --name-only origin/HEAD..HEAD`` to find repos with committed
+    Uses ``git diff --name-only <base_ref>..HEAD`` to find repos with committed
     changes relative to the remote default branch.  When ``origin/HEAD`` is not
-    configured the command returns non-zero; in that case a fallback of
-    ``git diff --name-only HEAD`` is attempted and an INFO message is logged.
+    configured, ``resolve_base_ref`` returns None and a fallback of
+    ``git diff --name-only HEAD`` is attempted with an INFO log.
 
     See also: ``step_utils.has_commits_ahead_of_base`` which performs a similar
-    check for PR/MR creation gating.
+    check for PR/MR creation gating. Both share ``resolve_base_ref`` for consistent
+    origin/HEAD resolution.
 
     Args:
         repo_paths: List of repository root paths to check
@@ -31,15 +33,16 @@ def detect_affected_repos(repo_paths: list[str], adw_id: str = "detect") -> list
     affected = []
     for rp in repo_paths:
         try:
-            result = subprocess.run(
-                ["git", "diff", "--name-only", "origin/HEAD..HEAD"],
-                capture_output=True,
-                text=True,
-                timeout=30,
-                cwd=rp,
-            )
-            if result.returncode == 0:
-                if result.stdout.strip():
+            base_ref = resolve_base_ref(rp, logger)
+            if base_ref is not None:
+                result = subprocess.run(
+                    ["git", "diff", "--name-only", f"{base_ref}..HEAD"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    cwd=rp,
+                )
+                if result.returncode == 0 and result.stdout.strip():
                     affected.append(rp)
             else:
                 # origin/HEAD is not configured (e.g., no remote or shallow clone).

--- a/src/rouge/core/workflow/repo_filter.py
+++ b/src/rouge/core/workflow/repo_filter.py
@@ -1,0 +1,55 @@
+"""Shared helper for filtering repositories to those affected by implementation."""
+
+from typing import Optional, Tuple
+
+from rouge.core.utils import get_logger
+from rouge.core.workflow.artifacts import ImplementArtifact
+from rouge.core.workflow.step_base import WorkflowContext
+from rouge.core.workflow.types import ImplementData
+
+
+def get_affected_repos(
+    context: WorkflowContext,
+) -> Tuple[list[str], Optional[ImplementData]]:
+    """Load ImplementArtifact and return filtered repo list.
+
+    Returns:
+        Tuple of (affected_repo_paths, implement_data).
+        If implement artifact is missing or has no affected_repos,
+        returns ([], None).
+
+    The returned repo list preserves the order from context.repo_paths,
+    filtered to only repos present in implement_data.affected_repos.
+    Validates that affected_repos is a subset of context.repo_paths.
+    """
+    logger = get_logger(context.adw_id)
+
+    implement_data = context.load_optional_artifact(
+        "implement_data",
+        "implement",
+        ImplementArtifact,
+        lambda a: a.implement_data,
+    )
+
+    if implement_data is None:
+        logger.debug("No implement artifact found; returning empty affected repos")
+        return [], None
+
+    affected_set = set(implement_data.affected_repos)
+
+    # Warn about unknown repos in affected_repos
+    known_set = set(context.repo_paths)
+    unknown = affected_set - known_set
+    if unknown:
+        logger.warning(
+            "affected_repos contains paths not in context.repo_paths: %s",
+            unknown,
+        )
+
+    # Filter context.repo_paths preserving order
+    filtered = [rp for rp in context.repo_paths if rp in affected_set]
+
+    if not filtered:
+        logger.info("No repos affected by implementation")
+
+    return filtered, implement_data

--- a/src/rouge/core/workflow/repo_filter.py
+++ b/src/rouge/core/workflow/repo_filter.py
@@ -1,11 +1,40 @@
 """Shared helper for filtering repositories to those affected by implementation."""
 
+import subprocess
 from typing import Optional, Tuple
 
 from rouge.core.utils import get_logger
 from rouge.core.workflow.artifacts import ImplementArtifact
 from rouge.core.workflow.step_base import WorkflowContext
 from rouge.core.workflow.types import ImplementData
+
+
+def detect_affected_repos(repo_paths: list[str], adw_id: str = "detect") -> list[str]:
+    """Detect which repos have commits ahead of the remote default branch.
+
+    Args:
+        repo_paths: List of repository root paths to check
+        adw_id: ADW ID used for logger namespacing (defaults to "detect")
+
+    Returns:
+        List of repo paths that have commits ahead of origin/HEAD
+    """
+    logger = get_logger(adw_id)
+    affected = []
+    for rp in repo_paths:
+        try:
+            result = subprocess.run(
+                ["git", "diff", "--name-only", "origin/HEAD..HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=rp,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                affected.append(rp)
+        except (subprocess.TimeoutExpired, OSError) as e:
+            logger.debug("Could not detect changes in %s: %s", rp, e)
+    return affected
 
 
 def get_affected_repos(
@@ -15,8 +44,8 @@ def get_affected_repos(
 
     Returns:
         Tuple of (affected_repo_paths, implement_data).
-        If implement artifact is missing or has no affected_repos,
-        returns ([], None).
+        If implement artifact is missing, returns ([], None).
+        If artifact exists but no repos match, returns ([], implement_data).
 
     The returned repo list preserves the order from context.repo_paths,
     filtered to only repos present in implement_data.affected_repos.

--- a/src/rouge/core/workflow/repo_filter.py
+++ b/src/rouge/core/workflow/repo_filter.py
@@ -1,7 +1,6 @@
 """Shared helper for filtering repositories to those affected by implementation."""
 
 import subprocess
-from typing import Optional, Tuple
 
 from rouge.core.utils import get_logger
 from rouge.core.workflow.artifacts import ImplementArtifact
@@ -72,13 +71,13 @@ def detect_affected_repos(repo_paths: list[str], adw_id: str = "detect") -> list
 
 def get_affected_repos(
     context: WorkflowContext,
-) -> Tuple[list[str], Optional[ImplementData]]:
+) -> tuple[list[str], ImplementData]:
     """Load ImplementArtifact and return filtered repo list.
 
     Returns:
         Tuple of (affected_repo_paths, implement_data).
-        If implement artifact is missing, returns ([], None).
         If artifact exists but no repos match, returns ([], implement_data).
+        Raises StepInputError if the implement artifact is missing.
 
     The returned repo list preserves the order from context.repo_paths,
     filtered to only repos present in implement_data.affected_repos.
@@ -86,16 +85,12 @@ def get_affected_repos(
     """
     logger = get_logger(context.adw_id)
 
-    implement_data = context.load_optional_artifact(
+    implement_data = context.load_required_artifact(
         "implement_data",
         "implement",
         ImplementArtifact,
         lambda a: a.implement_data,
     )
-
-    if implement_data is None:
-        logger.debug("No implement artifact found; returning empty affected repos")
-        return [], None
 
     affected_set = set(implement_data.affected_repos)
 

--- a/src/rouge/core/workflow/repo_filter.py
+++ b/src/rouge/core/workflow/repo_filter.py
@@ -46,20 +46,25 @@ def detect_affected_repos(repo_paths: list[str], adw_id: str = "detect") -> list
                     affected.append(rp)
             else:
                 # origin/HEAD is not configured (e.g., no remote or shallow clone).
-                # Fall back to a plain HEAD diff to detect uncommitted/staged changes.
+                # Fall back to counting total commits on HEAD — consistent with
+                # has_commits_ahead_of_base which uses the same approach.
+                # Unlike git diff --name-only HEAD, this detects committed changes too.
                 logger.info(
-                    "origin/HEAD unavailable for %s; falling back to git diff --name-only HEAD",
+                    "origin/HEAD unavailable for %s; falling back to git rev-list --count HEAD",
                     rp,
                 )
                 fallback_result = subprocess.run(
-                    ["git", "diff", "--name-only", "HEAD"],
+                    ["git", "rev-list", "--count", "HEAD"],
                     capture_output=True,
                     text=True,
                     timeout=30,
                     cwd=rp,
                 )
-                if fallback_result.returncode == 0 and fallback_result.stdout.strip():
-                    affected.append(rp)
+                try:
+                    if fallback_result.returncode == 0 and int(fallback_result.stdout.strip()) >= 1:
+                        affected.append(rp)
+                except ValueError:
+                    pass
         except (subprocess.TimeoutExpired, OSError) as e:
             logger.debug("Could not detect changes in %s: %s", rp, e)
     return affected

--- a/src/rouge/core/workflow/repo_filter.py
+++ b/src/rouge/core/workflow/repo_filter.py
@@ -12,6 +12,14 @@ from rouge.core.workflow.types import ImplementData
 def detect_affected_repos(repo_paths: list[str], adw_id: str = "detect") -> list[str]:
     """Detect which repos have commits ahead of the remote default branch.
 
+    Uses ``git diff --name-only origin/HEAD..HEAD`` to find repos with committed
+    changes relative to the remote default branch.  When ``origin/HEAD`` is not
+    configured the command returns non-zero; in that case a fallback of
+    ``git diff --name-only HEAD`` is attempted and an INFO message is logged.
+
+    See also: ``step_utils.has_commits_ahead_of_base`` which performs a similar
+    check for PR/MR creation gating.
+
     Args:
         repo_paths: List of repository root paths to check
         adw_id: ADW ID used for logger namespacing (defaults to "detect")
@@ -30,8 +38,25 @@ def detect_affected_repos(repo_paths: list[str], adw_id: str = "detect") -> list
                 timeout=30,
                 cwd=rp,
             )
-            if result.returncode == 0 and result.stdout.strip():
-                affected.append(rp)
+            if result.returncode == 0:
+                if result.stdout.strip():
+                    affected.append(rp)
+            else:
+                # origin/HEAD is not configured (e.g., no remote or shallow clone).
+                # Fall back to a plain HEAD diff to detect uncommitted/staged changes.
+                logger.info(
+                    "origin/HEAD unavailable for %s; falling back to git diff --name-only HEAD",
+                    rp,
+                )
+                fallback_result = subprocess.run(
+                    ["git", "diff", "--name-only", "HEAD"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    cwd=rp,
+                )
+                if fallback_result.returncode == 0 and fallback_result.stdout.strip():
+                    affected.append(rp)
         except (subprocess.TimeoutExpired, OSError) as e:
             logger.debug("Could not detect changes in %s: %s", rp, e)
     return affected

--- a/src/rouge/core/workflow/step_registry.py
+++ b/src/rouge/core/workflow/step_registry.py
@@ -424,54 +424,50 @@ def _register_default_steps(registry: StepRegistry) -> None:
         description="Execute the implementation plan",
     )
 
-    # 5. CodeQualityStep: requires implement (ordering-only), produces code-quality artifact
+    # 5. CodeQualityStep: requires implement, produces code-quality artifact
     registry.register(
         CodeQualityStep,
         slug="code-quality",
         dependencies=["implement"],
         outputs=["code-quality"],
-        description=(
-            "Run code quality checks (linting, type checking). "
-            "Ordering-only dependency on implement."
-        ),
-        dependency_kinds={"implement": "ordering-only"},
+        description="Run code quality checks on repos affected by implementation",
     )
 
-    # 10. ComposeRequestStep: requires implement (ordering-only), produces compose-request artifact
+    # 10. ComposeRequestStep: requires implement, produces compose-request artifact
     registry.register(
         ComposeRequestStep,
         slug="compose-request",
         dependencies=["implement"],
         outputs=["compose-request"],
-        description=(
-            "Prepare pull request metadata and commits. " "Ordering-only dependency on implement."
-        ),
-        dependency_kinds={"implement": "ordering-only"},
+        description="Prepare pull request metadata for repos affected by implementation",
     )
 
-    # 11. GhPullRequestStep: requires compose-request (optional), produces gh-pull-request artifact
+    # 11. GhPullRequestStep: requires implement and compose-request (both optional),
+    # produces gh-pull-request artifact
     registry.register(
         GhPullRequestStep,
         slug="gh-pull-request",
-        dependencies=["compose-request"],
+        dependencies=["implement", "compose-request"],
         outputs=["gh-pull-request"],
         description=(
-            "Create GitHub pull request via gh CLI. " "Optional dependency on compose-request."
+            "Create GitHub pull request via gh CLI. "
+            "Optional dependencies on implement and compose-request."
         ),
-        dependency_kinds={"compose-request": "optional"},
+        dependency_kinds={"implement": "optional", "compose-request": "optional"},
     )
 
-    # 12. GlabPullRequestStep: requires compose-request (optional),
+    # 12. GlabPullRequestStep: requires implement and compose-request (both optional),
     # produces glab-pull-request artifact
     registry.register(
         GlabPullRequestStep,
         slug="glab-pull-request",
-        dependencies=["compose-request"],
+        dependencies=["implement", "compose-request"],
         outputs=["glab-pull-request"],
         description=(
-            "Create GitLab merge request via glab CLI. " "Optional dependency on compose-request."
+            "Create GitLab merge request via glab CLI. "
+            "Optional dependencies on implement and compose-request."
         ),
-        dependency_kinds={"compose-request": "optional"},
+        dependency_kinds={"implement": "optional", "compose-request": "optional"},
     )
 
     # 13. PatchPlanStep: requires fetch-patch, produces plan

--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -1,6 +1,8 @@
 """Shared utility helpers for workflow step implementations."""
 
+import logging
 import re
+import subprocess
 from typing import Any, Optional
 
 from rouge.core.models import CommentPayload
@@ -48,6 +50,46 @@ def _sanitize_for_logging(text: Optional[str], max_length: int = MAX_LOG_LENGTH)
     if len(sanitized) > max_length:
         return sanitized[:max_length] + "..."
     return sanitized
+
+
+def has_commits_ahead_of_base(repo_path: str, logger: logging.Logger) -> bool:
+    """Check whether the current branch has commits ahead of origin/HEAD.
+
+    Resolves the remote default branch ref via ``git rev-parse --verify origin/HEAD``
+    and counts commits with ``git rev-list --count``.  Falls back to ``HEAD~1`` when
+    origin/HEAD is unavailable (e.g., shallow clones or repos without a remote).
+
+    Args:
+        repo_path: Absolute path to the git repository.
+        logger: Logger instance for debug output.
+
+    Returns:
+        True if the branch has at least one commit ahead of the base ref,
+        False if it is even with the base or the check cannot be completed.
+    """
+    try:
+        base_branch_result = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", "origin/HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=repo_path,
+        )
+        base_ref = (
+            base_branch_result.stdout.strip() if base_branch_result.returncode == 0 else "HEAD~1"
+        )
+        ahead_result = subprocess.run(
+            ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=repo_path,
+        )
+        ahead_count = int(ahead_result.stdout.strip()) if ahead_result.returncode == 0 else 0
+        return ahead_count > 0
+    except (subprocess.TimeoutExpired, OSError, ValueError) as e:
+        logger.debug("Delta check failed for %s: %s", repo_path, e)
+        return True  # Proceed with PR/MR creation if check fails
 
 
 def _emit_and_log(issue_id: int, adw_id: str, text: str, raw: dict[str, Any]) -> None:

--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -52,11 +52,38 @@ def sanitize_for_logging(text: Optional[str], max_length: int = MAX_LOG_LENGTH) 
     return sanitized
 
 
+def resolve_base_ref(repo_path: str, logger: logging.Logger) -> Optional[str]:
+    """Resolve the remote default branch ref (origin/HEAD) for a repository.
+
+    Used by both ``has_commits_ahead_of_base`` and ``repo_filter.detect_affected_repos``
+    to share origin/HEAD resolution logic and keep fallback behaviour consistent.
+
+    Args:
+        repo_path: Absolute path to the git repository.
+        logger: Logger instance for debug output.
+
+    Returns:
+        The resolved ref string (e.g. a SHA or symbolic ref) when origin/HEAD is
+        available, or None when it is not configured (shallow clone, no remote, etc.).
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", "origin/HEAD"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=repo_path,
+    )
+    if result.returncode == 0:
+        return result.stdout.strip()
+    logger.debug("origin/HEAD unavailable for %s", repo_path)
+    return None
+
+
 def has_commits_ahead_of_base(repo_path: str, logger: logging.Logger) -> bool:
     """Check whether the current branch has commits ahead of origin/HEAD.
 
-    Resolves the remote default branch ref via ``git rev-parse --verify origin/HEAD``
-    and counts commits with ``git rev-list --count``.  When origin/HEAD is unavailable
+    Resolves the remote default branch ref via ``resolve_base_ref`` and counts
+    commits with ``git rev-list --count``.  When origin/HEAD is unavailable
     (e.g., shallow clones or repos without a remote), falls back to counting total
     commits on HEAD — if there is at least one commit the branch is considered ahead.
 
@@ -72,15 +99,8 @@ def has_commits_ahead_of_base(repo_path: str, logger: logging.Logger) -> bool:
         False if it is even with the base or the check cannot be completed.
     """
     try:
-        base_branch_result = subprocess.run(
-            ["git", "rev-parse", "--verify", "--quiet", "origin/HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            cwd=repo_path,
-        )
-        if base_branch_result.returncode == 0:
-            base_ref = base_branch_result.stdout.strip()
+        base_ref = resolve_base_ref(repo_path, logger)
+        if base_ref is not None:
             ahead_result = subprocess.run(
                 ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
                 capture_output=True,

--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -95,8 +95,8 @@ def has_commits_ahead_of_base(repo_path: str, logger: logging.Logger) -> bool:
         logger: Logger instance for debug output.
 
     Returns:
-        True if the branch has at least one commit ahead of the base ref,
-        False if it is even with the base or the check cannot be completed.
+        True if at least one commit ahead of the base ref, or if the check fails
+        (fail-open to avoid skipping PR creation). False if even with base.
     """
     try:
         base_ref = resolve_base_ref(repo_path, logger)

--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -13,7 +13,7 @@ from rouge.core.utils import get_logger
 MAX_LOG_LENGTH = 500
 
 
-def _sanitize_for_logging(text: Optional[str], max_length: int = MAX_LOG_LENGTH) -> str:
+def sanitize_for_logging(text: Optional[str], max_length: int = MAX_LOG_LENGTH) -> str:
     """Sanitize text by redacting secrets and truncating to safe length.
 
     Redacts common secret patterns (API keys, tokens, emails) and truncates
@@ -56,8 +56,12 @@ def has_commits_ahead_of_base(repo_path: str, logger: logging.Logger) -> bool:
     """Check whether the current branch has commits ahead of origin/HEAD.
 
     Resolves the remote default branch ref via ``git rev-parse --verify origin/HEAD``
-    and counts commits with ``git rev-list --count``.  Falls back to ``HEAD~1`` when
-    origin/HEAD is unavailable (e.g., shallow clones or repos without a remote).
+    and counts commits with ``git rev-list --count``.  When origin/HEAD is unavailable
+    (e.g., shallow clones or repos without a remote), falls back to counting total
+    commits on HEAD — if there is at least one commit the branch is considered ahead.
+
+    See also: ``repo_filter.detect_affected_repos`` which performs a similar check
+    for fallback repo detection during the implement step.
 
     Args:
         repo_path: Absolute path to the git repository.
@@ -75,24 +79,39 @@ def has_commits_ahead_of_base(repo_path: str, logger: logging.Logger) -> bool:
             timeout=30,
             cwd=repo_path,
         )
-        base_ref = (
-            base_branch_result.stdout.strip() if base_branch_result.returncode == 0 else "HEAD~1"
-        )
-        ahead_result = subprocess.run(
-            ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            cwd=repo_path,
-        )
-        ahead_count = int(ahead_result.stdout.strip()) if ahead_result.returncode == 0 else 0
-        return ahead_count > 0
+        if base_branch_result.returncode == 0:
+            base_ref = base_branch_result.stdout.strip()
+            ahead_result = subprocess.run(
+                ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=repo_path,
+            )
+            ahead_count = int(ahead_result.stdout.strip()) if ahead_result.returncode == 0 else 0
+            return ahead_count > 0
+        else:
+            # origin/HEAD not configured — fall back to total commit count on this branch.
+            # A single-commit branch (e.g., during tests or shallow clone) should still
+            # trigger PR/MR creation rather than silently skipping.
+            logger.debug(
+                "origin/HEAD unavailable for %s; falling back to total commit count", repo_path
+            )
+            total_result = subprocess.run(
+                ["git", "rev-list", "--count", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=repo_path,
+            )
+            total_count = int(total_result.stdout.strip()) if total_result.returncode == 0 else 0
+            return total_count >= 1
     except (subprocess.TimeoutExpired, OSError, ValueError) as e:
         logger.debug("Delta check failed for %s: %s", repo_path, e)
         return True  # Proceed with PR/MR creation if check fails
 
 
-def _emit_and_log(issue_id: int, adw_id: str, text: str, raw: dict[str, Any]) -> None:
+def emit_and_log(issue_id: int, adw_id: str, text: str, raw: dict[str, Any]) -> None:
     """Helper to emit comment and log based on status.
 
     Args:

--- a/src/rouge/core/workflow/steps/code_quality_step.py
+++ b/src/rouge/core/workflow/steps/code_quality_step.py
@@ -3,10 +3,8 @@
 from rouge.core.agent import execute_template
 from rouge.core.agents.claude import ClaudeAgentTemplateRequest
 from rouge.core.json_parser import parse_and_validate_json
-from rouge.core.models import CommentPayload
 from rouge.core.notifications.comments import (
     emit_artifact_comment,
-    emit_comment_from_payload,
     log_artifact_comment_status,
 )
 from rouge.core.prompts import PromptId
@@ -15,6 +13,7 @@ from rouge.core.workflow.artifacts import CodeQualityArtifact
 from rouge.core.workflow.repo_filter import get_affected_repos
 from rouge.core.workflow.shared import AGENT_CODE_QUALITY_CHECKER
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
+from rouge.core.workflow.step_utils import emit_and_log
 from rouge.core.workflow.types import StepResult
 
 # Required fields for code quality output JSON
@@ -131,22 +130,15 @@ class CodeQualityStep(WorkflowStep):
 
             # Insert progress comment - best-effort, non-blocking
             if context.issue_id is not None:
-                payload = CommentPayload(
-                    issue_id=context.issue_id,
-                    adw_id=context.adw_id,
-                    text="Code quality checks completed.",
-                    raw={
+                emit_and_log(
+                    context.issue_id,
+                    context.adw_id,
+                    "Code quality checks completed.",
+                    {
                         "text": "Code quality checks completed.",
                         "result": parse_result.data,
                     },
-                    source="system",
-                    kind="workflow",
                 )
-                status, msg = emit_comment_from_payload(payload)
-                if status == "success":
-                    logger.debug(msg)
-                else:
-                    logger.error(msg)
 
             return StepResult.ok(None, parsed_data=parse_result.data)
 

--- a/src/rouge/core/workflow/steps/code_quality_step.py
+++ b/src/rouge/core/workflow/steps/code_quality_step.py
@@ -12,6 +12,7 @@ from rouge.core.notifications.comments import (
 from rouge.core.prompts import PromptId
 from rouge.core.utils import get_logger
 from rouge.core.workflow.artifacts import CodeQualityArtifact
+from rouge.core.workflow.repo_filter import get_affected_repos
 from rouge.core.workflow.shared import AGENT_CODE_QUALITY_CHECKER
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
 from rouge.core.workflow.types import StepResult
@@ -65,11 +66,25 @@ class CodeQualityStep(WorkflowStep):
         """
         logger = get_logger(context.adw_id)
 
+        # Filter repos to only those affected by implementation
+        affected_repos, _implement_data = get_affected_repos(context)
+
+        if not affected_repos:
+            logger.info("No repos affected by implementation; skipping code quality checks")
+            skip_artifact = CodeQualityArtifact(
+                workflow_id=context.adw_id,
+                output="code-quality",
+                tools=["skipped"],
+                parsed_data={"skipped": True, "reason": "no affected repos"},
+            )
+            context.artifact_store.write_artifact(skip_artifact)
+            return StepResult.ok(None)
+
         try:
             request = ClaudeAgentTemplateRequest(
                 agent_name=AGENT_CODE_QUALITY_CHECKER,
                 prompt_id=PromptId.CODE_QUALITY,
-                args=[],
+                args=affected_repos,
                 adw_id=context.adw_id,
                 issue_id=context.issue_id,
                 model="sonnet",

--- a/src/rouge/core/workflow/steps/compose_commits_step.py
+++ b/src/rouge/core/workflow/steps/compose_commits_step.py
@@ -18,7 +18,7 @@ from rouge.core.utils import get_logger
 from rouge.core.workflow.artifacts import ComposeCommitsArtifact
 from rouge.core.workflow.shared import AGENT_COMMIT_COMPOSER
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
-from rouge.core.workflow.step_utils import _emit_and_log, _sanitize_for_logging
+from rouge.core.workflow.step_utils import emit_and_log, sanitize_for_logging
 from rouge.core.workflow.types import StepResult
 
 # Required fields for compose-commits output JSON
@@ -184,7 +184,7 @@ class ComposeCommitsStep(WorkflowStep):
             if branch_check.returncode != 0:
                 error_msg = f"Cannot push {repo_path}: not on a branch (detached HEAD state)"
                 logger.error(error_msg)
-                _emit_and_log(
+                emit_and_log(
                     issue_id,
                     adw_id,
                     error_msg,
@@ -215,7 +215,7 @@ class ComposeCommitsStep(WorkflowStep):
                     f"{push_result.stderr}"
                 )
                 logger.warning(error_msg)
-                _emit_and_log(
+                emit_and_log(
                     issue_id,
                     adw_id,
                     error_msg,
@@ -229,7 +229,7 @@ class ComposeCommitsStep(WorkflowStep):
         except subprocess.TimeoutExpired:
             error_msg = f"git push timed out after 60 seconds for {repo_path}"
             logger.exception(error_msg)
-            _emit_and_log(
+            emit_and_log(
                 issue_id,
                 adw_id,
                 error_msg,
@@ -239,7 +239,7 @@ class ComposeCommitsStep(WorkflowStep):
         except (OSError, PermissionError, ValueError, subprocess.SubprocessError) as e:
             error_msg = f"Error updating PR/MR with patch commits for {repo_path}: {e}"
             logger.exception(error_msg)
-            _emit_and_log(
+            emit_and_log(
                 issue_id,
                 adw_id,
                 error_msg,
@@ -283,13 +283,13 @@ class ComposeCommitsStep(WorkflowStep):
             response = execute_template(request)
 
             logger.debug("compose_commits response: success=%s", response.success)
-            logger.debug("Compose commits LLM response: %s", _sanitize_for_logging(response.output))
+            logger.debug("Compose commits LLM response: %s", sanitize_for_logging(response.output))
 
             if not response.success:
-                sanitized_output = _sanitize_for_logging(response.output)
+                sanitized_output = sanitize_for_logging(response.output)
                 error_msg = f"Compose commits failed: {sanitized_output}"
                 logger.warning(error_msg)
-                _emit_and_log(
+                emit_and_log(
                     context.require_issue_id,
                     context.adw_id,
                     error_msg,
@@ -305,10 +305,10 @@ class ComposeCommitsStep(WorkflowStep):
             )
             if not parse_result.success:
                 raw_error = parse_result.error or "Compose commits JSON parsing failed"
-                sanitized_error = _sanitize_for_logging(raw_error)
+                sanitized_error = sanitize_for_logging(raw_error)
                 error_msg = sanitized_error or raw_error
                 logger.warning("Compose commits JSON parsing failed: %s", error_msg)
-                _emit_and_log(
+                emit_and_log(
                     context.require_issue_id,
                     context.adw_id,
                     error_msg,
@@ -331,7 +331,7 @@ class ComposeCommitsStep(WorkflowStep):
                 status, msg = emit_artifact_comment(context.issue_id, context.adw_id, artifact)
                 log_artifact_comment_status(status, msg)
 
-            _emit_and_log(
+            emit_and_log(
                 context.require_issue_id,
                 context.adw_id,
                 "Commits composed successfully.",
@@ -339,11 +339,11 @@ class ComposeCommitsStep(WorkflowStep):
             )
 
         except Exception as e:
-            sanitized_error = _sanitize_for_logging(str(e))
+            sanitized_error = sanitize_for_logging(str(e))
             error_msg = f"Compose commits failed: {sanitized_error}"
-            tb = _sanitize_for_logging(traceback.format_exc())
+            tb = sanitize_for_logging(traceback.format_exc())
             logger.exception(error_msg)
-            _emit_and_log(
+            emit_and_log(
                 context.require_issue_id,
                 context.adw_id,
                 error_msg,
@@ -363,7 +363,7 @@ class ComposeCommitsStep(WorkflowStep):
             if not platform or not pr_url:
                 warn_msg = f"No existing PR/MR found for {repo_path}, skipping push"
                 logger.warning(warn_msg)
-                _emit_and_log(
+                emit_and_log(
                     issue_id,
                     context.adw_id,
                     warn_msg,
@@ -388,7 +388,7 @@ class ComposeCommitsStep(WorkflowStep):
                     f"{pat_name} environment variable not set"
                 )
                 logger.info(skip_msg)
-                _emit_and_log(
+                emit_and_log(
                     issue_id,
                     context.adw_id,
                     skip_msg,
@@ -405,7 +405,7 @@ class ComposeCommitsStep(WorkflowStep):
             if push_result.success:
                 succeeded.append(repo_path)
                 comment_msg = f"Commits pushed to branch for {repo_path}"
-                _emit_and_log(
+                emit_and_log(
                     issue_id,
                     context.adw_id,
                     comment_msg,
@@ -433,7 +433,7 @@ class ComposeCommitsStep(WorkflowStep):
         combined = "; ".join(errors)
         error_msg = f"All repo pushes failed: {combined}"
         logger.warning(error_msg)
-        _emit_and_log(
+        emit_and_log(
             issue_id,
             context.adw_id,
             error_msg,

--- a/src/rouge/core/workflow/steps/compose_request_step.py
+++ b/src/rouge/core/workflow/steps/compose_request_step.py
@@ -14,6 +14,7 @@ from rouge.core.notifications.comments import (
 from rouge.core.prompts import PromptId
 from rouge.core.utils import get_logger
 from rouge.core.workflow.artifacts import ComposeRequestArtifact
+from rouge.core.workflow.repo_filter import get_affected_repos
 from rouge.core.workflow.shared import AGENT_PULL_REQUEST_BUILDER
 from rouge.core.workflow.status import update_status
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
@@ -73,11 +74,26 @@ class ComposeRequestStep(WorkflowStep):
         """
         logger = get_logger(context.adw_id)
 
+        # Filter repos to only those affected by implementation
+        affected_repos, _implement_data = get_affected_repos(context)
+
+        if not affected_repos:
+            logger.info("No repos affected by implementation; skipping PR preparation")
+            skip_artifact = ComposeRequestArtifact(
+                workflow_id=context.adw_id,
+                title="No changes",
+                summary="No repos were affected by implementation",
+                commits=[],
+            )
+            context.artifact_store.write_artifact(skip_artifact)
+            self._finalize_workflow(context)
+            return StepResult.ok(None)
+
         try:
             request = ClaudeAgentTemplateRequest(
                 agent_name=AGENT_PULL_REQUEST_BUILDER,
                 prompt_id=PromptId.PULL_REQUEST,
-                args=context.repo_paths,
+                args=affected_repos,
                 adw_id=context.adw_id,
                 issue_id=context.require_issue_id,
                 model="sonnet",

--- a/src/rouge/core/workflow/steps/compose_request_step.py
+++ b/src/rouge/core/workflow/steps/compose_request_step.py
@@ -18,7 +18,7 @@ from rouge.core.workflow.repo_filter import get_affected_repos
 from rouge.core.workflow.shared import AGENT_PULL_REQUEST_BUILDER
 from rouge.core.workflow.status import update_status
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
-from rouge.core.workflow.step_utils import _sanitize_for_logging
+from rouge.core.workflow.step_utils import sanitize_for_logging
 from rouge.core.workflow.types import StepResult
 
 # Required fields for pull request output JSON
@@ -108,7 +108,7 @@ class ComposeRequestStep(WorkflowStep):
             response = execute_template(request)
 
             logger.debug("pull_request response: success=%s", response.success)
-            logger.debug("PR preparation LLM response: %s", _sanitize_for_logging(response.output))
+            logger.debug("PR preparation LLM response: %s", sanitize_for_logging(response.output))
 
             # Emit raw LLM response for debugging visibility
             payload = CommentPayload(

--- a/src/rouge/core/workflow/steps/compose_request_step.py
+++ b/src/rouge/core/workflow/steps/compose_request_step.py
@@ -5,10 +5,8 @@ from typing import Any, Dict
 from rouge.core.agent import execute_template
 from rouge.core.agents.claude import ClaudeAgentTemplateRequest
 from rouge.core.json_parser import parse_and_validate_json
-from rouge.core.models import CommentPayload
 from rouge.core.notifications.comments import (
     emit_artifact_comment,
-    emit_comment_from_payload,
     log_artifact_comment_status,
 )
 from rouge.core.prompts import PromptId
@@ -18,7 +16,7 @@ from rouge.core.workflow.repo_filter import get_affected_repos
 from rouge.core.workflow.shared import AGENT_PULL_REQUEST_BUILDER
 from rouge.core.workflow.status import update_status
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
-from rouge.core.workflow.step_utils import sanitize_for_logging
+from rouge.core.workflow.step_utils import emit_and_log, sanitize_for_logging
 from rouge.core.workflow.types import StepResult
 
 # Required fields for pull request output JSON
@@ -111,22 +109,15 @@ class ComposeRequestStep(WorkflowStep):
             logger.debug("PR preparation LLM response: %s", sanitize_for_logging(response.output))
 
             # Emit raw LLM response for debugging visibility
-            payload = CommentPayload(
-                issue_id=context.require_issue_id,
-                adw_id=context.adw_id,
-                text="PR preparation LLM response received",
-                raw={
+            emit_and_log(
+                context.require_issue_id,
+                context.adw_id,
+                "PR preparation LLM response received",
+                {
                     "output": "pr-preparation-response",
                     "llm_response": response.output[:500] if response.output else "",
                 },
-                source="system",
-                kind="workflow",
             )
-            status, msg = emit_comment_from_payload(payload)
-            if status == "success":
-                logger.debug(msg)
-            else:
-                logger.error(msg)
 
             if not response.success:
                 logger.warning("Pull request preparation failed: %s", response.output)
@@ -152,19 +143,12 @@ class ComposeRequestStep(WorkflowStep):
                 self._store_pr_details(parse_result.data, context)
 
             # Insert progress comment - best-effort, non-blocking
-            payload = CommentPayload(
-                issue_id=context.require_issue_id,
-                adw_id=context.adw_id,
-                text="Pull request prepared.",
-                raw={"text": "Pull request prepared.", "result": parse_result.data},
-                source="system",
-                kind="workflow",
+            emit_and_log(
+                context.require_issue_id,
+                context.adw_id,
+                "Pull request prepared.",
+                {"text": "Pull request prepared.", "result": parse_result.data},
             )
-            status, msg = emit_comment_from_payload(payload)
-            if status == "success":
-                logger.debug(msg)
-            else:
-                logger.error(msg)
 
             # Finalize workflow
             self._finalize_workflow(context)
@@ -183,24 +167,16 @@ class ComposeRequestStep(WorkflowStep):
         Args:
             context: Workflow context
         """
-        logger = get_logger(context.adw_id)
         # Update status to "completed" - best-effort, non-blocking
         update_status(context.require_issue_id, "completed", adw_id=context.adw_id)
 
         # Insert progress comment - best-effort, non-blocking
-        payload = CommentPayload(
-            issue_id=context.require_issue_id,
-            adw_id=context.adw_id,
-            text="Solution implemented successfully",
-            raw={"text": "Solution implemented successfully."},
-            source="system",
-            kind="workflow",
+        emit_and_log(
+            context.require_issue_id,
+            context.adw_id,
+            "Solution implemented successfully",
+            {"text": "Solution implemented successfully."},
         )
-        status, msg = emit_comment_from_payload(payload)
-        if status == "success":
-            logger.debug(msg)
-        else:
-            logger.error(msg)
 
     def _store_pr_details(self, pr_data: Dict[str, Any], context: WorkflowContext) -> None:
         """Store validated PR details in context for CreatePullRequestStep.

--- a/src/rouge/core/workflow/steps/gh_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/gh_pull_request_step.py
@@ -22,7 +22,7 @@ from rouge.core.workflow.artifacts import (
 )
 from rouge.core.workflow.repo_filter import get_affected_repos
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
-from rouge.core.workflow.step_utils import has_commits_ahead_of_base
+from rouge.core.workflow.step_utils import emit_and_log, has_commits_ahead_of_base
 from rouge.core.workflow.types import StepResult
 
 
@@ -54,19 +54,12 @@ class GhPullRequestStep(WorkflowStep):
 
         def _skip(msg: str) -> StepResult:
             logger.info(msg)
-            payload = CommentPayload(
-                issue_id=context.require_issue_id,
-                adw_id=context.adw_id,
-                text=msg,
-                raw={"output": "pull-request-skipped", "reason": msg},
-                source="system",
-                kind="workflow",
+            emit_and_log(
+                context.require_issue_id,
+                context.adw_id,
+                msg,
+                {"output": "pull-request-skipped", "reason": msg},
             )
-            status, comment_msg = emit_comment_from_payload(payload)
-            if status == "success":
-                logger.debug(comment_msg)
-            else:
-                logger.error(comment_msg)
             return StepResult.ok(None)
 
         pr_details = context.load_optional_artifact(
@@ -342,9 +335,10 @@ class GhPullRequestStep(WorkflowStep):
                 except (FileNotFoundError, ValueError) as e:
                     logger.debug("Could not load existing gh-pull-request artifact: %s", e)
 
-            # Filter repos to affected ones if implement artifact is available
+            # Use affected_repos from implement artifact; skip PR creation when empty
+            # (empty means implementation touched no repos — no fallback to all repos)
             affected_repos, _implement_data = get_affected_repos(context)
-            target_repos = affected_repos if _implement_data is not None else context.repo_paths
+            target_repos = affected_repos
 
             # Iterate — delegate per-repo work to _process_repo
             for repo_path in target_repos:

--- a/src/rouge/core/workflow/steps/gh_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/gh_pull_request_step.py
@@ -373,16 +373,6 @@ class GhPullRequestStep(WorkflowStep):
 
             return StepResult.ok(None)
 
-        except subprocess.TimeoutExpired:
-            error_msg = "gh pr create timed out after 120 seconds"
-            logger.warning(error_msg)
-            emit_and_log(
-                context.require_issue_id,
-                context.adw_id,
-                error_msg,
-                {"output": "pull-request-failed", "error": error_msg},
-            )
-            return StepResult.fail(error_msg)
         except Exception as e:
             error_msg = f"Error creating pull request: {e}"
             logger.exception(error_msg)

--- a/src/rouge/core/workflow/steps/gh_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/gh_pull_request_step.py
@@ -18,6 +18,7 @@ from rouge.core.workflow.artifacts import (
     GhPullRequestArtifact,
     PullRequestEntry,
 )
+from rouge.core.workflow.repo_filter import get_affected_repos
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
 from rouge.core.workflow.types import StepResult
 
@@ -150,7 +151,11 @@ class GhPullRequestStep(WorkflowStep):
                 except (FileNotFoundError, ValueError) as e:
                     logger.debug("Could not load existing gh-pull-request artifact: %s", e)
 
-            for repo_path in context.repo_paths:
+            # Filter repos to affected ones if implement artifact is available
+            affected_repos, _implement_data = get_affected_repos(context)
+            target_repos = affected_repos if affected_repos else context.repo_paths
+
+            for repo_path in target_repos:
                 repo_name = os.path.basename(repo_path)
 
                 # Layer 1: Already done check — skip if this repo_path is already recorded
@@ -230,6 +235,39 @@ class GhPullRequestStep(WorkflowStep):
                                     continue
                     except (subprocess.TimeoutExpired, json.JSONDecodeError) as e:
                         logger.debug("Could not check for existing PR in %s: %s", repo_path, e)
+
+                # Check if branch has meaningful delta vs base
+                try:
+                    base_branch_result = subprocess.run(
+                        ["git", "rev-parse", "--verify", "--quiet", "origin/HEAD"],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                        cwd=repo_path,
+                    )
+                    base_ref = (
+                        base_branch_result.stdout.strip()
+                        if base_branch_result.returncode == 0
+                        else "HEAD~1"
+                    )
+                    ahead_result = subprocess.run(
+                        ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                        cwd=repo_path,
+                    )
+                    ahead_count = (
+                        int(ahead_result.stdout.strip()) if ahead_result.returncode == 0 else 0
+                    )
+                    if ahead_count == 0:
+                        logger.info(
+                            "Skipping PR/MR creation for %s: no commits ahead of base",
+                            repo_name,
+                        )
+                        continue
+                except (subprocess.TimeoutExpired, OSError, ValueError):
+                    pass  # Proceed with PR/MR creation if check fails
 
                 # Layer 3: Push + create new PR
                 push_cmd = ["git", "push", "--set-upstream", "origin", "HEAD"]

--- a/src/rouge/core/workflow/steps/gh_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/gh_pull_request_step.py
@@ -8,10 +8,8 @@ import shutil
 import subprocess
 from typing import Optional
 
-from rouge.core.models import CommentPayload
 from rouge.core.notifications.comments import (
     emit_artifact_comment,
-    emit_comment_from_payload,
     log_artifact_comment_status,
 )
 from rouge.core.utils import get_logger
@@ -231,14 +229,25 @@ class GhPullRequestStep(WorkflowStep):
 
         logger.debug("Executing: %s (cwd=%s)", " ".join(cmd), repo_path)
 
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=120,
-            cwd=repo_path,
-        )
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=120,
+                cwd=repo_path,
+            )
+        except subprocess.TimeoutExpired:
+            error_msg = f"gh pr create timed out for {repo_name} after 120 seconds"
+            logger.warning(error_msg)
+            emit_and_log(
+                context.require_issue_id,
+                context.adw_id,
+                error_msg,
+                {"output": "pull-request-failed", "error": error_msg},
+            )
+            return
 
         if result.returncode != 0:
             error_msg = (
@@ -251,19 +260,12 @@ class GhPullRequestStep(WorkflowStep):
                 result.returncode,
                 result.stderr,
             )
-            payload = CommentPayload(
-                issue_id=context.require_issue_id,
-                adw_id=context.adw_id,
-                text=error_msg,
-                raw={"output": "pull-request-failed", "error": error_msg},
-                source="system",
-                kind="workflow",
+            emit_and_log(
+                context.require_issue_id,
+                context.adw_id,
+                error_msg,
+                {"output": "pull-request-failed", "error": error_msg},
             )
-            status, msg = emit_comment_from_payload(payload)
-            if status == "success":
-                logger.debug(msg)
-            else:
-                logger.error(msg)
             return
 
         # Parse PR URL from output (gh pr create outputs the URL)
@@ -362,53 +364,32 @@ class GhPullRequestStep(WorkflowStep):
                     "output": "pull-request-created",
                     "urls": pr_urls,
                 }
-                payload = CommentPayload(
-                    issue_id=context.require_issue_id,
-                    adw_id=context.adw_id,
-                    text=f"Pull request(s) created: {', '.join(pr_urls)}",
-                    raw=comment_data,
-                    source="system",
-                    kind="workflow",
+                emit_and_log(
+                    context.require_issue_id,
+                    context.adw_id,
+                    f"Pull request(s) created: {', '.join(pr_urls)}",
+                    comment_data,
                 )
-                status, msg = emit_comment_from_payload(payload)
-                if status == "success":
-                    logger.debug(msg)
-                else:
-                    logger.error(msg)
 
             return StepResult.ok(None)
 
         except subprocess.TimeoutExpired:
             error_msg = "gh pr create timed out after 120 seconds"
             logger.warning(error_msg)
-            payload = CommentPayload(
-                issue_id=context.require_issue_id,
-                adw_id=context.adw_id,
-                text=error_msg,
-                raw={"output": "pull-request-failed", "error": error_msg},
-                source="system",
-                kind="workflow",
+            emit_and_log(
+                context.require_issue_id,
+                context.adw_id,
+                error_msg,
+                {"output": "pull-request-failed", "error": error_msg},
             )
-            status, msg = emit_comment_from_payload(payload)
-            if status == "success":
-                logger.debug(msg)
-            else:
-                logger.exception(msg)
             return StepResult.fail(error_msg)
         except Exception as e:
             error_msg = f"Error creating pull request: {e}"
             logger.exception(error_msg)
-            payload = CommentPayload(
-                issue_id=context.require_issue_id,
-                adw_id=context.adw_id,
-                text=error_msg,
-                raw={"output": "pull-request-failed", "error": error_msg},
-                source="system",
-                kind="workflow",
+            emit_and_log(
+                context.require_issue_id,
+                context.adw_id,
+                error_msg,
+                {"output": "pull-request-failed", "error": error_msg},
             )
-            status, msg = emit_comment_from_payload(payload)
-            if status == "success":
-                logger.debug(msg)
-            else:
-                logger.error(msg)
             return StepResult.fail(error_msg)

--- a/src/rouge/core/workflow/steps/gh_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/gh_pull_request_step.py
@@ -1,10 +1,12 @@
 """Create GitHub pull request step implementation."""
 
 import json
+import logging
 import os
 import re
 import shutil
 import subprocess
+from typing import Optional
 
 from rouge.core.models import CommentPayload
 from rouge.core.notifications.comments import (
@@ -20,6 +22,7 @@ from rouge.core.workflow.artifacts import (
 )
 from rouge.core.workflow.repo_filter import get_affected_repos
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
+from rouge.core.workflow.step_utils import has_commits_ahead_of_base
 from rouge.core.workflow.types import StepResult
 
 
@@ -35,8 +38,274 @@ class GhPullRequestStep(WorkflowStep):
         # PR creation is best-effort - workflow continues on failure
         return False
 
+    def _validate_prerequisites(
+        self, context: WorkflowContext, logger: logging.Logger
+    ) -> tuple[Optional[dict], Optional[StepResult]]:
+        """Validate all prerequisites for PR creation.
+
+        Args:
+            context: Workflow context
+            logger: Logger instance
+
+        Returns:
+            Tuple of (pr_details, early_return). If early_return is not None,
+            the caller should return it immediately. Otherwise pr_details is valid.
+        """
+
+        def _skip(msg: str) -> StepResult:
+            logger.info(msg)
+            payload = CommentPayload(
+                issue_id=context.require_issue_id,
+                adw_id=context.adw_id,
+                text=msg,
+                raw={"output": "pull-request-skipped", "reason": msg},
+                source="system",
+                kind="workflow",
+            )
+            status, comment_msg = emit_comment_from_payload(payload)
+            if status == "success":
+                logger.debug(comment_msg)
+            else:
+                logger.error(comment_msg)
+            return StepResult.ok(None)
+
+        pr_details = context.load_optional_artifact(
+            "pr_details",
+            "compose-request",
+            ComposeRequestArtifact,
+            lambda a: {"title": a.title, "summary": a.summary, "commits": a.commits},
+        )
+
+        if not pr_details:
+            return None, _skip("PR creation skipped: no PR details in context")
+
+        if not pr_details.get("title", ""):
+            return None, _skip("PR creation skipped: PR title is empty")
+
+        if not os.environ.get("GITHUB_PAT"):
+            return None, _skip("PR creation skipped: GITHUB_PAT environment variable not set")
+
+        if not shutil.which("gh"):
+            logger.debug("Current PATH: %s", os.environ.get("PATH", ""))
+            return None, _skip("PR creation skipped: gh CLI not found in PATH")
+
+        return pr_details, None
+
+    def _process_repo(
+        self,
+        repo_path: str,
+        title: str,
+        summary: str,
+        env: dict,
+        pull_requests: list[PullRequestEntry],
+        context: WorkflowContext,
+        logger: logging.Logger,
+    ) -> None:
+        """Process a single repository: adopt existing PR or push and create a new one.
+
+        Modifies pull_requests in place and persists the artifact incrementally.
+
+        Args:
+            repo_path: Absolute path to the repository.
+            title: PR title.
+            summary: PR body / summary.
+            env: Environment dict with GH_TOKEN set.
+            pull_requests: Running list of PR entries (mutated in place).
+            context: Workflow context.
+            logger: Logger instance.
+        """
+        repo_name = os.path.basename(repo_path)
+
+        # Layer 1: Already done check — skip if this repo_path is already recorded
+        if any(entry.repo_path == repo_path for entry in pull_requests):
+            logger.info(
+                "PR for repo %s (%s) already recorded, skipping",
+                repo_name,
+                repo_path,
+            )
+            return
+
+        # Determine the current branch name for this repo
+        branch_result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=repo_path,
+        )
+        branch_name = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
+
+        # Layer 2: Adopt existing remote PR if one already exists for this branch
+        if branch_name:
+            list_cmd = [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch_name,
+                "--json",
+                "url,number",
+            ]
+            logger.debug("Checking for existing PR: %s (cwd=%s)", " ".join(list_cmd), repo_path)
+            try:
+                list_result = subprocess.run(
+                    list_cmd,
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                    timeout=60,
+                    cwd=repo_path,
+                )
+                if list_result.returncode == 0 and list_result.stdout.strip():
+                    pr_list = json.loads(list_result.stdout.strip())
+                    if pr_list:
+                        existing_pr = pr_list[0]
+                        pr_url = existing_pr.get("url", "")
+                        pr_number = existing_pr.get("number")
+                        if pr_url:
+                            logger.info(
+                                "Adopting existing PR for repo %s: %s",
+                                repo_name,
+                                pr_url,
+                            )
+                            entry = PullRequestEntry(
+                                repo=repo_name,
+                                repo_path=repo_path,
+                                url=pr_url,
+                                number=pr_number,
+                                adopted=True,
+                            )
+                            pull_requests.append(entry)
+                            context.artifact_store.write_artifact(
+                                GhPullRequestArtifact(
+                                    workflow_id=context.adw_id,
+                                    pull_requests=pull_requests,
+                                    platform="github",
+                                )
+                            )
+                            logger.debug(
+                                "Saved gh-pull-request artifact after adopting PR for %s",
+                                repo_name,
+                            )
+                            return
+            except (subprocess.TimeoutExpired, json.JSONDecodeError) as e:
+                logger.debug("Could not check for existing PR in %s: %s", repo_path, e)
+
+        # Check if branch has meaningful delta vs base
+        if not has_commits_ahead_of_base(repo_path, logger):
+            logger.info(
+                "Skipping PR/MR creation for %s: no commits ahead of base",
+                repo_name,
+            )
+            return
+
+        # Layer 3: Push + create new PR
+        push_cmd = ["git", "push", "--set-upstream", "origin", "HEAD"]
+        logger.debug("Pushing current branch to origin in %s...", repo_path)
+        try:
+            push_result = subprocess.run(
+                push_cmd,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=60,
+                cwd=repo_path,
+            )
+            if push_result.returncode == 0:
+                logger.debug("Branch pushed successfully for %s", repo_name)
+            else:
+                logger.debug(
+                    "git push failed for %s (exit code %d): %s",
+                    repo_name,
+                    push_result.returncode,
+                    push_result.stderr,
+                )
+        except subprocess.TimeoutExpired:
+            logger.debug("git push timed out for %s, continuing to PR creation", repo_name)
+        except OSError as e:
+            logger.exception("git push failed for %s: %s", repo_name, e)
+            raise
+
+        cmd = [
+            "gh",
+            "pr",
+            "create",
+            "--title",
+            title,
+            "--body",
+            summary,
+        ]
+
+        logger.debug("Executing: %s (cwd=%s)", " ".join(cmd), repo_path)
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+            cwd=repo_path,
+        )
+
+        if result.returncode != 0:
+            error_msg = (
+                f"gh pr create failed for {repo_name} "
+                f"(exit code {result.returncode}): {result.stderr}"
+            )
+            logger.warning(
+                "gh pr create failed for %s (exit code %d): %s",
+                repo_name,
+                result.returncode,
+                result.stderr,
+            )
+            payload = CommentPayload(
+                issue_id=context.require_issue_id,
+                adw_id=context.adw_id,
+                text=error_msg,
+                raw={"output": "pull-request-failed", "error": error_msg},
+                source="system",
+                kind="workflow",
+            )
+            status, msg = emit_comment_from_payload(payload)
+            if status == "success":
+                logger.debug(msg)
+            else:
+                logger.error(msg)
+            return
+
+        # Parse PR URL from output (gh pr create outputs the URL)
+        pr_url = result.stdout.strip()
+        logger.info("Pull request created for %s: %s", repo_name, pr_url)
+
+        # Extract PR number from URL
+        pr_number = None
+        number_match = re.search(r".*/pull/(\d+)", pr_url)
+        if number_match:
+            pr_number = int(number_match.group(1))
+
+        entry = PullRequestEntry(
+            repo=repo_name,
+            repo_path=repo_path,
+            url=pr_url,
+            number=pr_number,
+            adopted=False,
+        )
+        pull_requests.append(entry)
+
+        # Write artifact after each repo so partial progress survives failures
+        artifact = GhPullRequestArtifact(
+            workflow_id=context.adw_id,
+            pull_requests=pull_requests,
+            platform="github",
+        )
+        context.artifact_store.write_artifact(artifact)
+        logger.debug("Saved gh-pull-request artifact after creating PR for %s", repo_name)
+
     def run(self, context: WorkflowContext) -> StepResult:
         """Create GitHub pull request using gh CLI.
+
+        Validates prerequisites, loads artifacts, iterates affected repos,
+        persists progress, and emits a summary comment.
 
         Args:
             context: Workflow context
@@ -46,98 +315,20 @@ class GhPullRequestStep(WorkflowStep):
         """
         logger = get_logger(context.adw_id)
 
-        # Try to load pr_details from artifact if not in context (optional)
-        pr_details = context.load_optional_artifact(
-            "pr_details",
-            "compose-request",
-            ComposeRequestArtifact,
-            lambda a: {"title": a.title, "summary": a.summary, "commits": a.commits},
-        )
+        # Validate — returns early if any prerequisite is missing
+        pr_details, early_return = self._validate_prerequisites(context, logger)
+        if early_return is not None:
+            return early_return
 
-        if not pr_details:
-            skip_msg = "PR creation skipped: no PR details in context"
-            logger.info(skip_msg)
-            payload = CommentPayload(
-                issue_id=context.require_issue_id,
-                adw_id=context.adw_id,
-                text=skip_msg,
-                raw={"output": "pull-request-skipped", "reason": skip_msg},
-                source="system",
-                kind="workflow",
-            )
-            status, msg = emit_comment_from_payload(payload)
-            if status == "success":
-                logger.debug(msg)
-            else:
-                logger.error(msg)
-            return StepResult.ok(None)
-
+        assert pr_details is not None  # guaranteed by _validate_prerequisites
         title = pr_details.get("title", "")
         summary = pr_details.get("summary", "")
         commits = pr_details.get("commits", [])
 
-        if not title:
-            skip_msg = "PR creation skipped: PR title is empty"
-            logger.info(skip_msg)
-            payload = CommentPayload(
-                issue_id=context.require_issue_id,
-                adw_id=context.adw_id,
-                text=skip_msg,
-                raw={"output": "pull-request-skipped", "reason": skip_msg},
-                source="system",
-                kind="workflow",
-            )
-            status, msg = emit_comment_from_payload(payload)
-            if status == "success":
-                logger.debug(msg)
-            else:
-                logger.error(msg)
-            return StepResult.ok(None)
-
-        # Check for GITHUB_PAT environment variable
-        github_pat = os.environ.get("GITHUB_PAT")
-        if not github_pat:
-            skip_msg = "PR creation skipped: GITHUB_PAT environment variable not set"
-            logger.info(skip_msg)
-            payload = CommentPayload(
-                issue_id=context.require_issue_id,
-                adw_id=context.adw_id,
-                text=skip_msg,
-                raw={"output": "pull-request-skipped", "reason": skip_msg},
-                source="system",
-                kind="workflow",
-            )
-            status, msg = emit_comment_from_payload(payload)
-            if status == "success":
-                logger.debug(msg)
-            else:
-                logger.error(msg)
-            return StepResult.ok(None)
-
-        # Proactively check for gh CLI availability
-        if not shutil.which("gh"):
-            skip_msg = "PR creation skipped: gh CLI not found in PATH"
-            logger.info(skip_msg)
-            logger.debug("Current PATH: %s", os.environ.get("PATH", ""))
-            payload = CommentPayload(
-                issue_id=context.require_issue_id,
-                adw_id=context.adw_id,
-                text=skip_msg,
-                raw={"output": "pull-request-skipped", "reason": skip_msg},
-                source="system",
-                kind="workflow",
-            )
-            status, msg = emit_comment_from_payload(payload)
-            if status == "success":
-                logger.debug(msg)
-            else:
-                logger.error(msg)
-            return StepResult.ok(None)
-
         try:
             # Execute with GH_TOKEN environment variable
             env = os.environ.copy()
-            env["GH_TOKEN"] = github_pat
+            env["GH_TOKEN"] = os.environ["GITHUB_PAT"]
 
             # Seed pull_requests from existing artifact for rerun continuity (Layer 0)
             pull_requests: list[PullRequestEntry] = []
@@ -153,226 +344,13 @@ class GhPullRequestStep(WorkflowStep):
 
             # Filter repos to affected ones if implement artifact is available
             affected_repos, _implement_data = get_affected_repos(context)
-            target_repos = affected_repos if affected_repos else context.repo_paths
+            target_repos = affected_repos if _implement_data is not None else context.repo_paths
 
+            # Iterate — delegate per-repo work to _process_repo
             for repo_path in target_repos:
-                repo_name = os.path.basename(repo_path)
+                self._process_repo(repo_path, title, summary, env, pull_requests, context, logger)
 
-                # Layer 1: Already done check — skip if this repo_path is already recorded
-                already_done = any(entry.repo_path == repo_path for entry in pull_requests)
-                if already_done:
-                    logger.info(
-                        "PR for repo %s (%s) already recorded, skipping",
-                        repo_name,
-                        repo_path,
-                    )
-                    continue
-
-                # Determine the current branch name for this repo
-                branch_result = subprocess.run(
-                    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                    cwd=repo_path,
-                )
-                branch_name = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
-
-                # Layer 2: Adopt existing remote PR if one already exists for this branch
-                if branch_name:
-                    list_cmd = [
-                        "gh",
-                        "pr",
-                        "list",
-                        "--head",
-                        branch_name,
-                        "--json",
-                        "url,number",
-                    ]
-                    logger.debug(
-                        "Checking for existing PR: %s (cwd=%s)", " ".join(list_cmd), repo_path
-                    )
-                    try:
-                        list_result = subprocess.run(
-                            list_cmd,
-                            capture_output=True,
-                            text=True,
-                            env=env,
-                            timeout=60,
-                            cwd=repo_path,
-                        )
-                        if list_result.returncode == 0 and list_result.stdout.strip():
-                            pr_list = json.loads(list_result.stdout.strip())
-                            if pr_list:
-                                existing_pr = pr_list[0]
-                                pr_url = existing_pr.get("url", "")
-                                pr_number = existing_pr.get("number")
-                                if pr_url:
-                                    logger.info(
-                                        "Adopting existing PR for repo %s: %s",
-                                        repo_name,
-                                        pr_url,
-                                    )
-                                    entry = PullRequestEntry(
-                                        repo=repo_name,
-                                        repo_path=repo_path,
-                                        url=pr_url,
-                                        number=pr_number,
-                                        adopted=True,
-                                    )
-                                    pull_requests.append(entry)
-                                    context.artifact_store.write_artifact(
-                                        GhPullRequestArtifact(
-                                            workflow_id=context.adw_id,
-                                            pull_requests=pull_requests,
-                                            platform="github",
-                                        )
-                                    )
-                                    logger.debug(
-                                        "Saved gh-pull-request artifact after adopting PR for %s",
-                                        repo_name,
-                                    )
-                                    continue
-                    except (subprocess.TimeoutExpired, json.JSONDecodeError) as e:
-                        logger.debug("Could not check for existing PR in %s: %s", repo_path, e)
-
-                # Check if branch has meaningful delta vs base
-                try:
-                    base_branch_result = subprocess.run(
-                        ["git", "rev-parse", "--verify", "--quiet", "origin/HEAD"],
-                        capture_output=True,
-                        text=True,
-                        timeout=30,
-                        cwd=repo_path,
-                    )
-                    base_ref = (
-                        base_branch_result.stdout.strip()
-                        if base_branch_result.returncode == 0
-                        else "HEAD~1"
-                    )
-                    ahead_result = subprocess.run(
-                        ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
-                        capture_output=True,
-                        text=True,
-                        timeout=30,
-                        cwd=repo_path,
-                    )
-                    ahead_count = (
-                        int(ahead_result.stdout.strip()) if ahead_result.returncode == 0 else 0
-                    )
-                    if ahead_count == 0:
-                        logger.info(
-                            "Skipping PR/MR creation for %s: no commits ahead of base",
-                            repo_name,
-                        )
-                        continue
-                except (subprocess.TimeoutExpired, OSError, ValueError):
-                    pass  # Proceed with PR/MR creation if check fails
-
-                # Layer 3: Push + create new PR
-                push_cmd = ["git", "push", "--set-upstream", "origin", "HEAD"]
-                logger.debug("Pushing current branch to origin in %s...", repo_path)
-                try:
-                    push_result = subprocess.run(
-                        push_cmd,
-                        capture_output=True,
-                        text=True,
-                        env=env,
-                        timeout=60,
-                        cwd=repo_path,
-                    )
-                    if push_result.returncode == 0:
-                        logger.debug("Branch pushed successfully for %s", repo_name)
-                    else:
-                        logger.debug(
-                            "git push failed for %s (exit code %d): %s",
-                            repo_name,
-                            push_result.returncode,
-                            push_result.stderr,
-                        )
-                except subprocess.TimeoutExpired:
-                    logger.debug("git push timed out for %s, continuing to PR creation", repo_name)
-                except OSError as e:
-                    logger.exception("git push failed for %s: %s", repo_name, e)
-                    raise
-
-                cmd = [
-                    "gh",
-                    "pr",
-                    "create",
-                    "--title",
-                    title,
-                    "--body",
-                    summary,
-                ]
-
-                logger.debug("Executing: %s (cwd=%s)", " ".join(cmd), repo_path)
-
-                result = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    text=True,
-                    env=env,
-                    timeout=120,
-                    cwd=repo_path,
-                )
-
-                if result.returncode != 0:
-                    error_msg = (
-                        f"gh pr create failed for {repo_name} "
-                        f"(exit code {result.returncode}): {result.stderr}"
-                    )
-                    logger.warning(
-                        "gh pr create failed for %s (exit code %d): %s",
-                        repo_name,
-                        result.returncode,
-                        result.stderr,
-                    )
-                    payload = CommentPayload(
-                        issue_id=context.require_issue_id,
-                        adw_id=context.adw_id,
-                        text=error_msg,
-                        raw={"output": "pull-request-failed", "error": error_msg},
-                        source="system",
-                        kind="workflow",
-                    )
-                    status, msg = emit_comment_from_payload(payload)
-                    if status == "success":
-                        logger.debug(msg)
-                    else:
-                        logger.error(msg)
-                    # Continue to next repo; partial progress is already saved
-                    continue
-
-                # Parse PR URL from output (gh pr create outputs the URL)
-                pr_url = result.stdout.strip()
-                logger.info("Pull request created for %s: %s", repo_name, pr_url)
-
-                # Extract PR number from URL
-                pr_number = None
-                number_match = re.search(r".*/pull/(\d+)", pr_url)
-                if number_match:
-                    pr_number = int(number_match.group(1))
-
-                entry = PullRequestEntry(
-                    repo=repo_name,
-                    repo_path=repo_path,
-                    url=pr_url,
-                    number=pr_number,
-                    adopted=False,
-                )
-                pull_requests.append(entry)
-
-                # Write artifact after each repo so partial progress survives failures
-                artifact = GhPullRequestArtifact(
-                    workflow_id=context.adw_id,
-                    pull_requests=pull_requests,
-                    platform="github",
-                )
-                context.artifact_store.write_artifact(artifact)
-                logger.debug("Saved gh-pull-request artifact after creating PR for %s", repo_name)
-
-            # Emit artifact comment and progress comment after all repos are processed
+            # Persist final artifact and emit summary comment
             if pull_requests:
                 artifact = GhPullRequestArtifact(
                     workflow_id=context.adw_id,

--- a/src/rouge/core/workflow/steps/glab_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/glab_pull_request_step.py
@@ -386,16 +386,6 @@ class GlabPullRequestStep(WorkflowStep):
 
             return StepResult.ok(None)
 
-        except subprocess.TimeoutExpired:
-            error_msg = "glab mr create timed out after 120 seconds"
-            logger.exception(error_msg)
-            emit_and_log(
-                context.require_issue_id,
-                context.adw_id,
-                error_msg,
-                {"output": "merge-request-failed", "error": error_msg},
-            )
-            return StepResult.fail(error_msg)
         except FileNotFoundError:
             error_msg = "glab CLI not found, skipping MR creation"
             logger.exception(error_msg)

--- a/src/rouge/core/workflow/steps/glab_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/glab_pull_request_step.py
@@ -17,7 +17,7 @@ from rouge.core.workflow.artifacts import (
 )
 from rouge.core.workflow.repo_filter import get_affected_repos
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
-from rouge.core.workflow.step_utils import _emit_and_log
+from rouge.core.workflow.step_utils import _emit_and_log, has_commits_ahead_of_base
 from rouge.core.workflow.types import StepResult
 
 
@@ -110,7 +110,7 @@ class GlabPullRequestStep(WorkflowStep):
 
             # Filter repos to affected ones if implement artifact is available
             affected_repos, _implement_data = get_affected_repos(context)
-            target_repos = affected_repos if affected_repos else context.repo_paths
+            target_repos = affected_repos if _implement_data is not None else context.repo_paths
 
             for repo_path in target_repos:
                 repo_name = os.path.basename(os.path.normpath(repo_path))
@@ -202,37 +202,12 @@ class GlabPullRequestStep(WorkflowStep):
                         logger.debug("Could not check for existing MR in %s: %s", repo_path, e)
 
                 # Check if branch has meaningful delta vs base
-                try:
-                    base_branch_result = subprocess.run(
-                        ["git", "rev-parse", "--verify", "--quiet", "origin/HEAD"],
-                        capture_output=True,
-                        text=True,
-                        timeout=30,
-                        cwd=repo_path,
+                if not has_commits_ahead_of_base(repo_path, logger):
+                    logger.info(
+                        "Skipping PR/MR creation for %s: no commits ahead of base",
+                        repo_name,
                     )
-                    base_ref = (
-                        base_branch_result.stdout.strip()
-                        if base_branch_result.returncode == 0
-                        else "HEAD~1"
-                    )
-                    ahead_result = subprocess.run(
-                        ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
-                        capture_output=True,
-                        text=True,
-                        timeout=30,
-                        cwd=repo_path,
-                    )
-                    ahead_count = (
-                        int(ahead_result.stdout.strip()) if ahead_result.returncode == 0 else 0
-                    )
-                    if ahead_count == 0:
-                        logger.info(
-                            "Skipping PR/MR creation for %s: no commits ahead of base",
-                            repo_name,
-                        )
-                        continue
-                except (subprocess.TimeoutExpired, OSError, ValueError):
-                    pass  # Proceed with PR/MR creation if check fails
+                    continue
 
                 # Layer 3: Push + create new MR
                 push_cmd = ["git", "push", "--set-upstream", "origin", "HEAD"]

--- a/src/rouge/core/workflow/steps/glab_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/glab_pull_request_step.py
@@ -1,9 +1,12 @@
 """Create GitLab merge request step implementation."""
 
 import json
+import logging
 import os
 import re
+import shutil
 import subprocess
+from typing import Optional
 
 from rouge.core.notifications.comments import (
     emit_artifact_comment,
@@ -17,7 +20,7 @@ from rouge.core.workflow.artifacts import (
 )
 from rouge.core.workflow.repo_filter import get_affected_repos
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
-from rouge.core.workflow.step_utils import _emit_and_log, has_commits_ahead_of_base
+from rouge.core.workflow.step_utils import emit_and_log, has_commits_ahead_of_base
 from rouge.core.workflow.types import StepResult
 
 
@@ -33,8 +36,284 @@ class GlabPullRequestStep(WorkflowStep):
         # MR creation is best-effort - workflow continues on failure
         return False
 
+    def _validate_prerequisites(
+        self, context: WorkflowContext, logger: logging.Logger
+    ) -> tuple[Optional[dict], Optional[StepResult]]:
+        """Validate all prerequisites for MR creation.
+
+        Args:
+            context: Workflow context
+            logger: Logger instance
+
+        Returns:
+            Tuple of (pr_details, early_return). If early_return is not None,
+            the caller should return it immediately. Otherwise pr_details is valid.
+        """
+
+        def _skip(msg: str) -> StepResult:
+            logger.info(msg)
+            emit_and_log(
+                context.require_issue_id,
+                context.adw_id,
+                msg,
+                {"output": "merge-request-skipped", "reason": msg},
+            )
+            return StepResult.ok(None)
+
+        pr_details = context.load_optional_artifact(
+            "pr_details",
+            "compose-request",
+            ComposeRequestArtifact,
+            lambda a: {"title": a.title, "summary": a.summary, "commits": a.commits},
+        )
+
+        if not pr_details:
+            return None, _skip("MR creation skipped: no PR details in context")
+
+        if not pr_details.get("title", ""):
+            return None, _skip("MR creation skipped: MR title is empty")
+
+        if not os.environ.get("GITLAB_PAT"):
+            return None, _skip("MR creation skipped: GITLAB_PAT environment variable not set")
+
+        if not shutil.which("glab"):
+            logger.debug("Current PATH: %s", os.environ.get("PATH", ""))
+            return None, _skip("MR creation skipped: glab CLI not found in PATH")
+
+        return pr_details, None
+
+    def _process_repo(
+        self,
+        repo_path: str,
+        title: str,
+        summary: str,
+        env: dict,
+        pull_requests: list[PullRequestEntry],
+        context: WorkflowContext,
+        logger: logging.Logger,
+    ) -> None:
+        """Process a single repository: adopt existing MR or push and create a new one.
+
+        Modifies pull_requests in place and persists the artifact incrementally.
+
+        Args:
+            repo_path: Absolute path to the repository.
+            title: MR title.
+            summary: MR body / summary.
+            env: Environment dict with GITLAB_TOKEN set.
+            pull_requests: Running list of MR entries (mutated in place).
+            context: Workflow context.
+            logger: Logger instance.
+        """
+        repo_name = os.path.basename(os.path.normpath(repo_path))
+
+        # Layer 1: Already done check — skip if this repo_path is already recorded
+        if any(entry.repo_path == repo_path for entry in pull_requests):
+            logger.info(
+                "MR for repo %s (%s) already recorded, skipping",
+                repo_name,
+                repo_path,
+            )
+            return
+
+        # Determine the current branch name for this repo
+        try:
+            branch_result = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=repo_path,
+            )
+            branch_name = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
+        except subprocess.TimeoutExpired:
+            logger.warning("git rev-parse timed out for %s, skipping branch detection", repo_name)
+            branch_name = ""
+
+        # Layer 2: Adopt existing remote MR if one already exists for this branch
+        if branch_name:
+            list_cmd = [
+                "glab",
+                "mr",
+                "list",
+                "--source-branch",
+                branch_name,
+                "--output",
+                "json",
+            ]
+            logger.debug("Checking for existing MR: %s (cwd=%s)", " ".join(list_cmd), repo_path)
+            try:
+                list_result = subprocess.run(
+                    list_cmd,
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                    timeout=60,
+                    cwd=repo_path,
+                )
+                if list_result.returncode == 0 and list_result.stdout.strip():
+                    mr_list = json.loads(list_result.stdout.strip())
+                    if mr_list:
+                        existing_mr = mr_list[0]
+                        mr_url = existing_mr.get("web_url", "")
+                        mr_number = existing_mr.get("iid")
+                        if mr_url:
+                            logger.info(
+                                "Adopting existing MR for repo %s: %s",
+                                repo_name,
+                                mr_url,
+                            )
+                            entry = PullRequestEntry(
+                                repo=repo_name,
+                                repo_path=repo_path,
+                                url=mr_url,
+                                number=mr_number,
+                                adopted=True,
+                            )
+                            pull_requests.append(entry)
+                            context.artifact_store.write_artifact(
+                                GlabPullRequestArtifact(
+                                    workflow_id=context.adw_id,
+                                    pull_requests=pull_requests,
+                                    platform="gitlab",
+                                )
+                            )
+                            logger.debug(
+                                "Saved glab-pull-request artifact after adopting MR for %s",
+                                repo_name,
+                            )
+                            return
+            except (subprocess.TimeoutExpired, json.JSONDecodeError) as e:
+                logger.debug("Could not check for existing MR in %s: %s", repo_path, e)
+
+        # Check if branch has meaningful delta vs base
+        if not has_commits_ahead_of_base(repo_path, logger):
+            logger.info(
+                "Skipping PR/MR creation for %s: no commits ahead of base",
+                repo_name,
+            )
+            return
+
+        # Layer 3: Push + create new MR
+        push_cmd = ["git", "push", "--set-upstream", "origin", "HEAD"]
+        logger.debug("Pushing current branch to origin in %s...", repo_path)
+        try:
+            push_result = subprocess.run(
+                push_cmd,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=60,
+                cwd=repo_path,
+            )
+            if push_result.returncode == 0:
+                logger.debug("Branch pushed successfully for %s", repo_name)
+            else:
+                logger.debug(
+                    "git push failed for %s (exit code %d): %s",
+                    repo_name,
+                    push_result.returncode,
+                    push_result.stderr,
+                )
+        except subprocess.TimeoutExpired:
+            logger.debug("git push timed out for %s, continuing to MR creation", repo_name)
+        except OSError as e:
+            logger.exception("git push failed for %s: %s", repo_name, e)
+            raise
+
+        cmd = [
+            "glab",
+            "mr",
+            "create",
+            "--title",
+            title,
+            "--description",
+            summary,
+        ]
+
+        logger.debug("Executing: %s (cwd=%s)", " ".join(cmd), repo_path)
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=120,
+                cwd=repo_path,
+            )
+        except subprocess.TimeoutExpired:
+            error_msg = f"glab mr create timed out for {repo_name} after 120 seconds"
+            logger.warning(error_msg)
+            emit_and_log(
+                context.require_issue_id,
+                context.adw_id,
+                error_msg,
+                {"output": "merge-request-failed", "error": error_msg},
+            )
+            return
+
+        if result.returncode != 0:
+            error_msg = (
+                f"glab mr create failed for {repo_name} "
+                f"(exit code {result.returncode}): {result.stderr}"
+            )
+            logger.warning(
+                "glab mr create failed for %s (exit code %d): %s",
+                repo_name,
+                result.returncode,
+                result.stderr,
+            )
+            emit_and_log(
+                context.require_issue_id,
+                context.adw_id,
+                error_msg,
+                {"output": "merge-request-failed", "error": error_msg},
+            )
+            # Continue to next repo; partial progress is already saved
+            return
+
+        # Parse MR URL from output (glab mr create outputs the URL)
+        url_match = re.search(r"https?://\S+/merge_requests/\d+", result.stdout)
+        if not url_match:
+            logger.error(
+                "Could not parse MR URL from glab output for %s: %r",
+                repo_name,
+                result.stdout,
+            )
+            return
+        mr_url = url_match.group(0)
+        logger.info("Merge request created for %s: %s", repo_name, mr_url)
+
+        # Extract MR number from URL
+        mr_number = None
+        number_match = re.search(r"/merge_requests/(\d+)", mr_url)
+        if number_match:
+            mr_number = int(number_match.group(1))
+
+        entry = PullRequestEntry(
+            repo=repo_name,
+            repo_path=repo_path,
+            url=mr_url,
+            number=mr_number,
+            adopted=False,
+        )
+        pull_requests.append(entry)
+
+        # Write artifact after each repo so partial progress survives failures
+        artifact = GlabPullRequestArtifact(
+            workflow_id=context.adw_id,
+            pull_requests=pull_requests,
+            platform="gitlab",
+        )
+        context.artifact_store.write_artifact(artifact)
+        logger.debug("Saved glab-pull-request artifact after creating MR for %s", repo_name)
+
     def run(self, context: WorkflowContext) -> StepResult:
         """Create GitLab merge request using glab CLI.
+
+        Validates prerequisites, loads artifacts, iterates affected repos,
+        persists progress, and emits a summary comment.
 
         Args:
             context: Workflow context
@@ -44,57 +323,20 @@ class GlabPullRequestStep(WorkflowStep):
         """
         logger = get_logger(context.adw_id)
 
-        # Try to load pr_details from artifact if not in context (optional)
-        pr_details = context.load_optional_artifact(
-            "pr_details",
-            "compose-request",
-            ComposeRequestArtifact,
-            lambda a: {"title": a.title, "summary": a.summary, "commits": a.commits},
-        )
+        # Validate — returns early if any prerequisite is missing
+        pr_details, early_return = self._validate_prerequisites(context, logger)
+        if early_return is not None:
+            return early_return
 
-        if not pr_details:
-            skip_msg = "MR creation skipped: no PR details in context"
-            logger.info(skip_msg)
-            _emit_and_log(
-                context.require_issue_id,
-                context.adw_id,
-                skip_msg,
-                {"output": "merge-request-skipped", "reason": skip_msg},
-            )
-            return StepResult.ok(None)
-
+        assert pr_details is not None  # guaranteed by _validate_prerequisites
         title = pr_details.get("title", "")
         summary = pr_details.get("summary", "")
         commits = pr_details.get("commits", [])
 
-        if not title:
-            skip_msg = "MR creation skipped: MR title is empty"
-            logger.info(skip_msg)
-            _emit_and_log(
-                context.require_issue_id,
-                context.adw_id,
-                skip_msg,
-                {"output": "merge-request-skipped", "reason": skip_msg},
-            )
-            return StepResult.ok(None)
-
-        # Check for GITLAB_PAT environment variable
-        gitlab_pat = os.environ.get("GITLAB_PAT")
-        if not gitlab_pat:
-            skip_msg = "MR creation skipped: GITLAB_PAT environment variable not set"
-            logger.info(skip_msg)
-            _emit_and_log(
-                context.require_issue_id,
-                context.adw_id,
-                skip_msg,
-                {"output": "merge-request-skipped", "reason": skip_msg},
-            )
-            return StepResult.ok(None)
-
         try:
             # Execute with GITLAB_TOKEN environment variable (glab uses GITLAB_TOKEN)
             env = os.environ.copy()
-            env["GITLAB_TOKEN"] = gitlab_pat
+            env["GITLAB_TOKEN"] = os.environ["GITLAB_PAT"]
 
             # Seed pull_requests from existing artifact for rerun continuity (Layer 0)
             pull_requests: list[PullRequestEntry] = []
@@ -105,226 +347,18 @@ class GlabPullRequestStep(WorkflowStep):
                     )
                     pull_requests = list(existing_artifact.pull_requests)
                     logger.debug("Seeded %d existing MR entries from artifact", len(pull_requests))
-                except Exception as e:
+                except (FileNotFoundError, ValueError) as e:
                     logger.debug("Could not load existing glab-pull-request artifact: %s", e)
 
             # Filter repos to affected ones if implement artifact is available
             affected_repos, _implement_data = get_affected_repos(context)
             target_repos = affected_repos if _implement_data is not None else context.repo_paths
 
+            # Iterate — delegate per-repo work to _process_repo
             for repo_path in target_repos:
-                repo_name = os.path.basename(os.path.normpath(repo_path))
+                self._process_repo(repo_path, title, summary, env, pull_requests, context, logger)
 
-                # Layer 1: Already done check — skip if this repo_path is already recorded
-                already_done = any(entry.repo_path == repo_path for entry in pull_requests)
-                if already_done:
-                    logger.info(
-                        "MR for repo %s (%s) already recorded, skipping",
-                        repo_name,
-                        repo_path,
-                    )
-                    continue
-
-                # Determine the current branch name for this repo
-                try:
-                    branch_result = subprocess.run(
-                        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-                        capture_output=True,
-                        text=True,
-                        timeout=30,
-                        cwd=repo_path,
-                    )
-                    branch_name = (
-                        branch_result.stdout.strip() if branch_result.returncode == 0 else ""
-                    )
-                except subprocess.TimeoutExpired:
-                    logger.warning(
-                        "git rev-parse timed out for %s, skipping branch detection", repo_name
-                    )
-                    branch_name = ""
-
-                # Layer 2: Adopt existing remote MR if one already exists for this branch
-                if branch_name:
-                    list_cmd = [
-                        "glab",
-                        "mr",
-                        "list",
-                        "--source-branch",
-                        branch_name,
-                        "--output",
-                        "json",
-                    ]
-                    logger.debug(
-                        "Checking for existing MR: %s (cwd=%s)", " ".join(list_cmd), repo_path
-                    )
-                    try:
-                        list_result = subprocess.run(
-                            list_cmd,
-                            capture_output=True,
-                            text=True,
-                            env=env,
-                            timeout=60,
-                            cwd=repo_path,
-                        )
-                        if list_result.returncode == 0 and list_result.stdout.strip():
-                            mr_list = json.loads(list_result.stdout.strip())
-                            if mr_list:
-                                existing_mr = mr_list[0]
-                                mr_url = existing_mr.get("web_url", "")
-                                mr_number = existing_mr.get("iid")
-                                if mr_url:
-                                    logger.info(
-                                        "Adopting existing MR for repo %s: %s",
-                                        repo_name,
-                                        mr_url,
-                                    )
-                                    entry = PullRequestEntry(
-                                        repo=repo_name,
-                                        repo_path=repo_path,
-                                        url=mr_url,
-                                        number=mr_number,
-                                        adopted=True,
-                                    )
-                                    pull_requests.append(entry)
-                                    context.artifact_store.write_artifact(
-                                        GlabPullRequestArtifact(
-                                            workflow_id=context.adw_id,
-                                            pull_requests=pull_requests,
-                                            platform="gitlab",
-                                        )
-                                    )
-                                    logger.debug(
-                                        "Saved glab-pull-request artifact after adopting MR for %s",
-                                        repo_name,
-                                    )
-                                    continue
-                    except (subprocess.TimeoutExpired, json.JSONDecodeError) as e:
-                        logger.debug("Could not check for existing MR in %s: %s", repo_path, e)
-
-                # Check if branch has meaningful delta vs base
-                if not has_commits_ahead_of_base(repo_path, logger):
-                    logger.info(
-                        "Skipping PR/MR creation for %s: no commits ahead of base",
-                        repo_name,
-                    )
-                    continue
-
-                # Layer 3: Push + create new MR
-                push_cmd = ["git", "push", "--set-upstream", "origin", "HEAD"]
-                logger.debug("Pushing current branch to origin in %s...", repo_path)
-                try:
-                    push_result = subprocess.run(
-                        push_cmd,
-                        capture_output=True,
-                        text=True,
-                        env=env,
-                        timeout=60,
-                        cwd=repo_path,
-                    )
-                    if push_result.returncode == 0:
-                        logger.debug("Branch pushed successfully for %s", repo_name)
-                    else:
-                        logger.debug(
-                            "git push failed for %s (exit code %d): %s",
-                            repo_name,
-                            push_result.returncode,
-                            push_result.stderr,
-                        )
-                except subprocess.TimeoutExpired:
-                    logger.debug("git push timed out for %s, continuing to MR creation", repo_name)
-                except OSError as e:
-                    logger.exception("git push failed for %s: %s", repo_name, e)
-                    raise
-
-                cmd = [
-                    "glab",
-                    "mr",
-                    "create",
-                    "--title",
-                    title,
-                    "--description",
-                    summary,
-                ]
-
-                logger.debug("Executing: %s (cwd=%s)", " ".join(cmd), repo_path)
-
-                try:
-                    result = subprocess.run(
-                        cmd,
-                        capture_output=True,
-                        text=True,
-                        env=env,
-                        timeout=120,
-                        cwd=repo_path,
-                    )
-                except subprocess.TimeoutExpired:
-                    error_msg = f"glab mr create timed out for {repo_name} after 120 seconds"
-                    logger.warning(error_msg)
-                    _emit_and_log(
-                        context.require_issue_id,
-                        context.adw_id,
-                        error_msg,
-                        {"output": "merge-request-failed", "error": error_msg},
-                    )
-                    continue
-
-                if result.returncode != 0:
-                    error_msg = (
-                        f"glab mr create failed for {repo_name} "
-                        f"(exit code {result.returncode}): {result.stderr}"
-                    )
-                    logger.warning(
-                        "glab mr create failed for %s (exit code %d): %s",
-                        repo_name,
-                        result.returncode,
-                        result.stderr,
-                    )
-                    _emit_and_log(
-                        context.require_issue_id,
-                        context.adw_id,
-                        error_msg,
-                        {"output": "merge-request-failed", "error": error_msg},
-                    )
-                    # Continue to next repo; partial progress is already saved
-                    continue
-
-                # Parse MR URL from output (glab mr create outputs the URL)
-                url_match = re.search(r"https?://\S+/merge_requests/\d+", result.stdout)
-                if not url_match:
-                    logger.error(
-                        "Could not parse MR URL from glab output for %s: %r",
-                        repo_name,
-                        result.stdout,
-                    )
-                    continue
-                mr_url = url_match.group(0)
-                logger.info("Merge request created for %s: %s", repo_name, mr_url)
-
-                # Extract MR number from URL
-                mr_number = None
-                number_match = re.search(r"/merge_requests/(\d+)", mr_url)
-                if number_match:
-                    mr_number = int(number_match.group(1))
-
-                entry = PullRequestEntry(
-                    repo=repo_name,
-                    repo_path=repo_path,
-                    url=mr_url,
-                    number=mr_number,
-                    adopted=False,
-                )
-                pull_requests.append(entry)
-
-                # Write artifact after each repo so partial progress survives failures
-                artifact = GlabPullRequestArtifact(
-                    workflow_id=context.adw_id,
-                    pull_requests=pull_requests,
-                    platform="gitlab",
-                )
-                context.artifact_store.write_artifact(artifact)
-                logger.debug("Saved glab-pull-request artifact after creating MR for %s", repo_name)
-
-            # Emit artifact comment and progress comment after all repos are processed
+            # Persist final artifact and emit summary comment
             if pull_requests:
                 artifact = GlabPullRequestArtifact(
                     workflow_id=context.adw_id,
@@ -342,7 +376,7 @@ class GlabPullRequestStep(WorkflowStep):
                     "output": "merge-request-created",
                     "urls": mr_urls,
                 }
-                _emit_and_log(
+                emit_and_log(
                     context.require_issue_id,
                     context.adw_id,
                     f"Merge request(s) created: {', '.join(mr_urls)}",
@@ -354,7 +388,7 @@ class GlabPullRequestStep(WorkflowStep):
         except subprocess.TimeoutExpired:
             error_msg = "glab mr create timed out after 120 seconds"
             logger.exception(error_msg)
-            _emit_and_log(
+            emit_and_log(
                 context.require_issue_id,
                 context.adw_id,
                 error_msg,
@@ -364,7 +398,7 @@ class GlabPullRequestStep(WorkflowStep):
         except FileNotFoundError:
             error_msg = "glab CLI not found, skipping MR creation"
             logger.exception(error_msg)
-            _emit_and_log(
+            emit_and_log(
                 context.require_issue_id,
                 context.adw_id,
                 error_msg,
@@ -374,7 +408,7 @@ class GlabPullRequestStep(WorkflowStep):
         except Exception as e:
             error_msg = f"Error creating merge request: {e}"
             logger.exception(error_msg)
-            _emit_and_log(
+            emit_and_log(
                 context.require_issue_id,
                 context.adw_id,
                 error_msg,

--- a/src/rouge/core/workflow/steps/glab_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/glab_pull_request_step.py
@@ -15,6 +15,7 @@ from rouge.core.workflow.artifacts import (
     GlabPullRequestArtifact,
     PullRequestEntry,
 )
+from rouge.core.workflow.repo_filter import get_affected_repos
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
 from rouge.core.workflow.step_utils import _emit_and_log
 from rouge.core.workflow.types import StepResult
@@ -107,7 +108,11 @@ class GlabPullRequestStep(WorkflowStep):
                 except Exception as e:
                     logger.debug("Could not load existing glab-pull-request artifact: %s", e)
 
-            for repo_path in context.repo_paths:
+            # Filter repos to affected ones if implement artifact is available
+            affected_repos, _implement_data = get_affected_repos(context)
+            target_repos = affected_repos if affected_repos else context.repo_paths
+
+            for repo_path in target_repos:
                 repo_name = os.path.basename(os.path.normpath(repo_path))
 
                 # Layer 1: Already done check — skip if this repo_path is already recorded
@@ -195,6 +200,39 @@ class GlabPullRequestStep(WorkflowStep):
                                     continue
                     except (subprocess.TimeoutExpired, json.JSONDecodeError) as e:
                         logger.debug("Could not check for existing MR in %s: %s", repo_path, e)
+
+                # Check if branch has meaningful delta vs base
+                try:
+                    base_branch_result = subprocess.run(
+                        ["git", "rev-parse", "--verify", "--quiet", "origin/HEAD"],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                        cwd=repo_path,
+                    )
+                    base_ref = (
+                        base_branch_result.stdout.strip()
+                        if base_branch_result.returncode == 0
+                        else "HEAD~1"
+                    )
+                    ahead_result = subprocess.run(
+                        ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                        cwd=repo_path,
+                    )
+                    ahead_count = (
+                        int(ahead_result.stdout.strip()) if ahead_result.returncode == 0 else 0
+                    )
+                    if ahead_count == 0:
+                        logger.info(
+                            "Skipping PR/MR creation for %s: no commits ahead of base",
+                            repo_name,
+                        )
+                        continue
+                except (subprocess.TimeoutExpired, OSError, ValueError):
+                    pass  # Proceed with PR/MR creation if check fails
 
                 # Layer 3: Push + create new MR
                 push_cmd = ["git", "push", "--set-upstream", "origin", "HEAD"]

--- a/src/rouge/core/workflow/steps/glab_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/glab_pull_request_step.py
@@ -350,9 +350,10 @@ class GlabPullRequestStep(WorkflowStep):
                 except (FileNotFoundError, ValueError) as e:
                     logger.debug("Could not load existing glab-pull-request artifact: %s", e)
 
-            # Filter repos to affected ones if implement artifact is available
+            # Use affected_repos from implement artifact; skip MR creation when empty
+            # (empty means implementation touched no repos — no fallback to all repos)
             affected_repos, _implement_data = get_affected_repos(context)
-            target_repos = affected_repos if _implement_data is not None else context.repo_paths
+            target_repos = affected_repos
 
             # Iterate — delegate per-repo work to _process_repo
             for repo_path in target_repos:

--- a/src/rouge/core/workflow/steps/implement_step.py
+++ b/src/rouge/core/workflow/steps/implement_step.py
@@ -178,7 +178,13 @@ class ImplementStep(WorkflowStep):
         repos_map: dict[str, list[str]] = {}
         for f_raw in implement_response.data.files_modified:
             f = os.path.normpath(f_raw)
-            # Skip paths that escape their directory via traversal
+            # Reject absolute paths — normpath resolves '..' so an LLM-supplied path
+            # like /repo/alpha/../../../etc/passwd becomes /etc/passwd (no '..' left).
+            # Rejecting absolute paths after normpath catches all such traversals.
+            if os.path.isabs(f):
+                logger.debug("Skipping absolute path: %s", f_raw)
+                continue
+            # Skip relative paths that still escape via traversal (e.g., ../foo)
             if ".." in f.split(os.sep):
                 logger.debug("Skipping path with traversal component: %s", f_raw)
                 continue

--- a/src/rouge/core/workflow/steps/implement_step.py
+++ b/src/rouge/core/workflow/steps/implement_step.py
@@ -1,7 +1,6 @@
 """Implementation step."""
 
 import os
-import subprocess
 
 from rouge.core.agent import execute_template
 from rouge.core.agents.claude import ClaudeAgentTemplateRequest
@@ -18,6 +17,7 @@ from rouge.core.workflow.artifacts import (
     ImplementArtifact,
     PlanArtifact,
 )
+from rouge.core.workflow.repo_filter import detect_affected_repos
 from rouge.core.workflow.shared import AGENT_PLAN_IMPLEMENTOR, IMPLEMENT_STEP_NAME
 from rouge.core.workflow.step_base import StepInputError, WorkflowContext, WorkflowStep
 from rouge.core.workflow.types import ImplementData, RepoChangeEntry, StepResult
@@ -42,32 +42,6 @@ IMPLEMENT_JSON_SCHEMA = """{
   },
   "required": ["files_modified", "git_diff_stat", "output", "status", "summary"]
 }"""
-
-
-def _detect_affected_repos(repo_paths: list[str]) -> list[str]:
-    """Detect which repos have uncommitted/staged changes via git diff.
-
-    Args:
-        repo_paths: List of repository root paths to check
-
-    Returns:
-        List of repo paths that have changes (uncommitted or staged)
-    """
-    affected = []
-    for rp in repo_paths:
-        try:
-            result = subprocess.run(
-                ["git", "diff", "--name-only", "HEAD"],
-                capture_output=True,
-                text=True,
-                timeout=30,
-                cwd=rp,
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                affected.append(rp)
-        except (subprocess.TimeoutExpired, OSError):
-            pass
-    return affected
 
 
 class ImplementStep(WorkflowStep):
@@ -202,15 +176,20 @@ class ImplementStep(WorkflowStep):
 
         # Derive affected_repos and per-repo entries from files_modified
         repos_map: dict[str, list[str]] = {}
-        for f in implement_response.data.files_modified:
+        for f_raw in implement_response.data.files_modified:
+            f = os.path.normpath(f_raw)
+            # Skip paths that escape their directory via traversal
+            if ".." in f.split(os.sep):
+                logger.debug("Skipping path with traversal component: %s", f_raw)
+                continue
             for rp in sorted(context.repo_paths, key=len, reverse=True):
-                if f.startswith(rp) or os.path.isfile(os.path.join(rp, f)):
+                if f.startswith(rp + os.sep) or os.path.isfile(os.path.join(rp, f)):
                     repos_map.setdefault(rp, []).append(f)
                     break
 
         # Fallback: use git diff detection if files_modified is empty
         if not repos_map and context.repo_paths:
-            detected = _detect_affected_repos(context.repo_paths)
+            detected = detect_affected_repos(context.repo_paths, context.adw_id)
             for rp in detected:
                 repos_map[rp] = []
 

--- a/src/rouge/core/workflow/steps/implement_step.py
+++ b/src/rouge/core/workflow/steps/implement_step.py
@@ -5,10 +5,8 @@ import os
 from rouge.core.agent import execute_template
 from rouge.core.agents.claude import ClaudeAgentTemplateRequest
 from rouge.core.json_parser import parse_and_validate_json
-from rouge.core.models import CommentPayload
 from rouge.core.notifications.comments import (
     emit_artifact_comment,
-    emit_comment_from_payload,
     log_artifact_comment_status,
 )
 from rouge.core.prompts import PromptId
@@ -20,6 +18,7 @@ from rouge.core.workflow.artifacts import (
 from rouge.core.workflow.repo_filter import detect_affected_repos
 from rouge.core.workflow.shared import AGENT_PLAN_IMPLEMENTOR, IMPLEMENT_STEP_NAME
 from rouge.core.workflow.step_base import StepInputError, WorkflowContext, WorkflowStep
+from rouge.core.workflow.step_utils import emit_and_log
 from rouge.core.workflow.types import ImplementData, RepoChangeEntry, StepResult
 
 # Required fields for implement output JSON
@@ -226,18 +225,11 @@ class ImplementStep(WorkflowStep):
         log_artifact_comment_status(status, msg)
 
         # Insert progress comment - best-effort, non-blocking
-        payload = CommentPayload(
-            issue_id=context.require_issue_id,
-            adw_id=context.adw_id,
-            text="Implementation complete.",
-            raw={"text": "Implementation complete."},
-            source="system",
-            kind="workflow",
+        emit_and_log(
+            context.require_issue_id,
+            context.adw_id,
+            "Implementation complete.",
+            {"text": "Implementation complete."},
         )
-        status, msg = emit_comment_from_payload(payload)
-        if status == "success":
-            logger.debug(msg)
-        else:
-            logger.error(msg)
 
         return StepResult.ok(None)

--- a/src/rouge/core/workflow/steps/implement_step.py
+++ b/src/rouge/core/workflow/steps/implement_step.py
@@ -1,5 +1,8 @@
 """Implementation step."""
 
+import os
+import subprocess
+
 from rouge.core.agent import execute_template
 from rouge.core.agents.claude import ClaudeAgentTemplateRequest
 from rouge.core.json_parser import parse_and_validate_json
@@ -17,7 +20,7 @@ from rouge.core.workflow.artifacts import (
 )
 from rouge.core.workflow.shared import AGENT_PLAN_IMPLEMENTOR, IMPLEMENT_STEP_NAME
 from rouge.core.workflow.step_base import StepInputError, WorkflowContext, WorkflowStep
-from rouge.core.workflow.types import ImplementData, StepResult
+from rouge.core.workflow.types import ImplementData, RepoChangeEntry, StepResult
 
 # Required fields for implement output JSON
 IMPLEMENT_REQUIRED_FIELDS = {
@@ -39,6 +42,32 @@ IMPLEMENT_JSON_SCHEMA = """{
   },
   "required": ["files_modified", "git_diff_stat", "output", "status", "summary"]
 }"""
+
+
+def _detect_affected_repos(repo_paths: list[str]) -> list[str]:
+    """Detect which repos have uncommitted/staged changes via git diff.
+
+    Args:
+        repo_paths: List of repository root paths to check
+
+    Returns:
+        List of repo paths that have changes (uncommitted or staged)
+    """
+    affected = []
+    for rp in repo_paths:
+        try:
+            result = subprocess.run(
+                ["git", "diff", "--name-only", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=rp,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                affected.append(rp)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+    return affected
 
 
 class ImplementStep(WorkflowStep):
@@ -107,8 +136,19 @@ class ImplementStep(WorkflowStep):
         if not parse_result.success:
             return StepResult.fail(parse_result.error or "JSON parsing failed")
 
+        parsed = parse_result.data or {}
+        files_modified = parsed.get("files_modified", [])
+        git_diff_stat = parsed.get("git_diff_stat", "")
+        summary = parsed.get("summary", "")
+
         return StepResult.ok(
-            ImplementData(output=response.output, session_id=response.session_id),
+            ImplementData(
+                output=response.output,
+                session_id=response.session_id,
+                files_modified=files_modified,
+                git_diff_stat=git_diff_stat,
+                summary=summary,
+            ),
             parsed_data=parse_result.data,
         )
 
@@ -159,6 +199,30 @@ class ImplementStep(WorkflowStep):
         if implement_response.data is None:
             logger.error("Implementation data missing despite successful response")
             return StepResult.fail("Implementation data missing despite successful response")
+
+        # Derive affected_repos and per-repo entries from files_modified
+        repos_map: dict[str, list[str]] = {}
+        for f in implement_response.data.files_modified:
+            for rp in sorted(context.repo_paths, key=len, reverse=True):
+                if f.startswith(rp) or os.path.isfile(os.path.join(rp, f)):
+                    repos_map.setdefault(rp, []).append(f)
+                    break
+
+        # Fallback: use git diff detection if files_modified is empty
+        if not repos_map and context.repo_paths:
+            detected = _detect_affected_repos(context.repo_paths)
+            for rp in detected:
+                repos_map[rp] = []
+
+        affected_repos = [rp for rp in context.repo_paths if rp in repos_map]
+        repo_entries = [
+            RepoChangeEntry(repo_path=rp, files_modified=repos_map.get(rp, []))
+            for rp in affected_repos
+        ]
+
+        # Update the implement data with derived fields
+        implement_response.data.affected_repos = affected_repos
+        implement_response.data.repos = repo_entries
 
         logger.debug("Output preview: %s...", implement_response.data.output[:200])
 

--- a/src/rouge/core/workflow/types.py
+++ b/src/rouge/core/workflow/types.py
@@ -5,7 +5,7 @@ replacing various patterns (tuples, booleans, response objects) with
 a unified StepResult[T] generic type.
 """
 
-from typing import Any, Dict, Generic, Optional, TypeVar
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -144,13 +144,31 @@ class PlanData(BaseModel):
     pr_number: Optional[int] = Field(default=None, gt=0)
 
 
+class RepoChangeEntry(BaseModel):
+    """Per-repo change summary from implementation."""
+
+    repo_path: str
+    files_modified: List[str] = []
+    git_diff_stat: str = ""
+
+
 class ImplementData(BaseModel):
     """Data payload for implementation results.
 
     Attributes:
         output: The implementation output text
         session_id: Optional session ID for continuation
+        affected_repos: List of repository paths affected by the implementation
+        repos: Per-repo change summaries
+        files_modified: Flat list of all modified file paths
+        git_diff_stat: Aggregate diff stat across all repos
+        summary: Human-readable summary of the implementation
     """
 
     output: str
     session_id: Optional[str] = None
+    affected_repos: List[str] = []
+    repos: List[RepoChangeEntry] = []
+    files_modified: List[str] = []
+    git_diff_stat: str = ""
+    summary: str = ""

--- a/src/rouge/core/workflow/types.py
+++ b/src/rouge/core/workflow/types.py
@@ -149,6 +149,8 @@ class RepoChangeEntry(BaseModel):
 
     repo_path: str
     files_modified: List[str] = []
+    # TODO: git_diff_stat is not yet populated per-repo by implement_step;
+    # it is always an empty string. Populate it or remove it in a future pass.
     git_diff_stat: str = ""
 
 

--- a/tests/test_code_quality_step.py
+++ b/tests/test_code_quality_step.py
@@ -1,13 +1,12 @@
-"""Tests for CodeQualityStep ordering-only dependency contract.
+"""Tests for CodeQualityStep behavior.
 
-Focuses on confirming that CodeQualityStep:
-- Does NOT read the implement artifact (ordering-only dependency)
-- Succeeds without any implement artifact being present
-- Only reads artifacts from its own execution (writes code-quality artifact)
+Covers:
+- Repo filtering via get_affected_repos (skip when no repos affected)
+- Passing affected repos as template args
+- Non-critical step classification
 """
 
 from pathlib import Path
-from typing import Any, Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -34,58 +33,60 @@ def base_context(store: ArtifactStore) -> WorkflowContext:
 
 
 class TestCodeQualityOrderingOnlyDependency:
-    """Tests that CodeQualityStep does not read the implement artifact."""
+    """Tests that CodeQualityStep handles missing implement artifact gracefully."""
+
+    def test_succeeds_without_implement_artifact(
+        self,
+        base_context: WorkflowContext,
+    ) -> None:
+        """CodeQualityStep writes a skip artifact when no implement artifact exists.
+
+        get_affected_repos returns ([], None) so the step skips early.
+        """
+        step = CodeQualityStep()
+        result = step.run(base_context)
+
+        assert result.success is True
+
+        # Verify skip artifact was written
+        artifact = base_context.artifact_store.read_artifact("code-quality")
+        assert artifact.tools == ["skipped"]
+        assert artifact.parsed_data == {"skipped": True, "reason": "no affected repos"}
+
+    def test_is_not_critical(self) -> None:
+        """CodeQualityStep is non-critical (best-effort)."""
+        step = CodeQualityStep()
+        assert step.is_critical is False
+
+
+class TestCodeQualityAffectedRepos:
+    """Tests for CodeQualityStep repo filtering behavior."""
 
     @patch("rouge.core.workflow.steps.code_quality_step.emit_comment_from_payload")
     @patch("rouge.core.workflow.steps.code_quality_step.emit_artifact_comment")
     @patch("rouge.core.workflow.steps.code_quality_step.log_artifact_comment_status")
     @patch("rouge.core.workflow.steps.code_quality_step.execute_template")
-    def test_does_not_read_implement_artifact(
+    @patch("rouge.core.workflow.steps.code_quality_step.get_affected_repos")
+    def test_passes_affected_repos_as_args(
         self,
+        mock_get_affected,
         mock_exec,
         _mock_log,
         mock_emit_artifact,
         mock_emit,
         base_context: WorkflowContext,
     ) -> None:
-        """CodeQualityStep never calls read_artifact('implement', ...)."""
+        """Affected repos are passed as template args."""
+        from rouge.core.workflow.types import ImplementData
+
+        mock_get_affected.return_value = (
+            ["/repo/a", "/repo/b"],
+            ImplementData(output="done"),
+        )
+
         mock_response = Mock()
         mock_response.success = True
         mock_response.output = '{"output": "code-quality", "tools": ["ruff"], "issues": []}'
-        mock_exec.return_value = mock_response
-        mock_emit.return_value = ("success", "ok")
-        mock_emit_artifact.return_value = ("success", "ok")
-
-        read_calls: list[str] = []
-        original_read = base_context.artifact_store.read_artifact
-
-        def tracking_read(artifact_type: str, model_class: Optional[type] = None) -> Any:
-            read_calls.append(artifact_type)
-            return original_read(artifact_type, model_class)
-
-        with patch.object(base_context.artifact_store, "read_artifact", side_effect=tracking_read):
-            step = CodeQualityStep()
-            step.run(base_context)
-
-        # Assert implement artifact was never read
-        assert "implement" not in read_calls
-
-    @patch("rouge.core.workflow.steps.code_quality_step.emit_comment_from_payload")
-    @patch("rouge.core.workflow.steps.code_quality_step.emit_artifact_comment")
-    @patch("rouge.core.workflow.steps.code_quality_step.log_artifact_comment_status")
-    @patch("rouge.core.workflow.steps.code_quality_step.execute_template")
-    def test_succeeds_without_implement_artifact(
-        self,
-        mock_exec,
-        _mock_log,
-        mock_emit_artifact,
-        mock_emit,
-        base_context: WorkflowContext,
-    ) -> None:
-        """CodeQualityStep succeeds even when no implement artifact exists."""
-        mock_response = Mock()
-        mock_response.success = True
-        mock_response.output = '{"output": "code-quality", "tools": ["mypy"], "issues": []}'
         mock_exec.return_value = mock_response
         mock_emit.return_value = ("success", "ok")
         mock_emit_artifact.return_value = ("success", "ok")
@@ -94,8 +95,19 @@ class TestCodeQualityOrderingOnlyDependency:
         result = step.run(base_context)
 
         assert result.success is True
+        # Verify args passed to template
+        call_args = mock_exec.call_args[0][0]
+        assert call_args.args == ["/repo/a", "/repo/b"]
 
-    def test_is_not_critical(self) -> None:
-        """CodeQualityStep is non-critical (best-effort)."""
+    def test_writes_skip_artifact_when_no_affected_repos(
+        self, base_context: WorkflowContext
+    ) -> None:
+        """Writes skip artifact when no repos affected."""
         step = CodeQualityStep()
-        assert step.is_critical is False
+        result = step.run(base_context)
+
+        assert result.success is True
+        # Verify skip artifact was written
+        artifact = base_context.artifact_store.read_artifact("code-quality")
+        assert artifact.tools == ["skipped"]
+        assert artifact.parsed_data == {"skipped": True, "reason": "no affected repos"}

--- a/tests/test_code_quality_step.py
+++ b/tests/test_code_quality_step.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from rouge.core.workflow.artifacts import ArtifactStore
-from rouge.core.workflow.step_base import WorkflowContext
+from rouge.core.workflow.step_base import StepInputError, WorkflowContext
 from rouge.core.workflow.steps.code_quality_step import CodeQualityStep
 
 
@@ -33,25 +33,21 @@ def base_context(store: ArtifactStore) -> WorkflowContext:
 
 
 class TestCodeQualityOrderingOnlyDependency:
-    """Tests that CodeQualityStep handles missing implement artifact gracefully."""
+    """Tests that CodeQualityStep raises when the implement artifact is missing."""
 
-    def test_succeeds_without_implement_artifact(
+    def test_raises_without_implement_artifact(
         self,
         base_context: WorkflowContext,
     ) -> None:
-        """CodeQualityStep writes a skip artifact when no implement artifact exists.
+        """CodeQualityStep raises StepInputError when the implement artifact is absent.
 
-        get_affected_repos returns ([], None) so the step skips early.
+        The implement dependency is declared as required in the step registry.
+        The pipeline framework handles non-critical steps that raise StepInputError
+        without aborting the workflow.
         """
         step = CodeQualityStep()
-        result = step.run(base_context)
-
-        assert result.success is True
-
-        # Verify skip artifact was written
-        artifact = base_context.artifact_store.read_artifact("code-quality")
-        assert artifact.tools == ["skipped"]
-        assert artifact.parsed_data == {"skipped": True, "reason": "no affected repos"}
+        with pytest.raises(StepInputError, match="Required artifact 'implement' not found"):
+            step.run(base_context)
 
     def test_is_not_critical(self) -> None:
         """CodeQualityStep is non-critical (best-effort)."""
@@ -62,7 +58,7 @@ class TestCodeQualityOrderingOnlyDependency:
 class TestCodeQualityAffectedRepos:
     """Tests for CodeQualityStep repo filtering behavior."""
 
-    @patch("rouge.core.workflow.steps.code_quality_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     @patch("rouge.core.workflow.steps.code_quality_step.emit_artifact_comment")
     @patch("rouge.core.workflow.steps.code_quality_step.log_artifact_comment_status")
     @patch("rouge.core.workflow.steps.code_quality_step.execute_template")
@@ -99,10 +95,15 @@ class TestCodeQualityAffectedRepos:
         call_args = mock_exec.call_args[0][0]
         assert call_args.args == ["/repo/a", "/repo/b"]
 
+    @patch("rouge.core.workflow.steps.code_quality_step.get_affected_repos")
     def test_writes_skip_artifact_when_no_affected_repos(
-        self, base_context: WorkflowContext
+        self, mock_get_affected, base_context: WorkflowContext
     ) -> None:
         """Writes skip artifact when no repos affected."""
+        from rouge.core.workflow.types import ImplementData
+
+        mock_get_affected.return_value = ([], ImplementData(output="done"))
+
         step = CodeQualityStep()
         result = step.run(base_context)
 

--- a/tests/test_compose_request_step.py
+++ b/tests/test_compose_request_step.py
@@ -176,13 +176,18 @@ class TestComposeRequestAffectedRepos:
 
     @patch("rouge.core.workflow.steps.compose_request_step.update_status")
     @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
+    @patch("rouge.core.workflow.steps.compose_request_step.get_affected_repos")
     def test_writes_skip_artifact_when_no_affected_repos(
         self,
+        mock_get_affected,
         mock_emit,
         mock_update_status,
         base_context: WorkflowContext,
     ) -> None:
         """Writes skip artifact and finalizes when no repos affected."""
+        from rouge.core.workflow.types import ImplementData
+
+        mock_get_affected.return_value = ([], ImplementData(output="done"))
         mock_emit.return_value = ("success", "ok")
         mock_update_status.return_value = None
 

--- a/tests/test_compose_request_step.py
+++ b/tests/test_compose_request_step.py
@@ -1,8 +1,10 @@
-"""Tests for ComposeRequestStep ordering-only dependency contract.
+"""Tests for ComposeRequestStep behavior.
 
-Focuses on confirming that ComposeRequestStep:
-- Does NOT read the acceptance artifact (ordering-only dependency)
-- Proceeds with its own agent-based logic without reading acceptance data
+Covers:
+- Ordering-only dependency on acceptance artifact (does not read it)
+- Repo filtering via get_affected_repos (skip when no repos affected)
+- Passing affected repos as template args
+- Non-critical step classification
 """
 
 from typing import Any, Optional
@@ -39,8 +41,10 @@ class TestComposeRequestOrderingOnlyDependency:
     @patch("rouge.core.workflow.steps.compose_request_step.emit_artifact_comment")
     @patch("rouge.core.workflow.steps.compose_request_step.log_artifact_comment_status")
     @patch("rouge.core.workflow.steps.compose_request_step.execute_template")
+    @patch("rouge.core.workflow.steps.compose_request_step.get_affected_repos")
     def test_does_not_read_acceptance_artifact(
         self,
+        mock_get_affected,
         mock_exec,
         _mock_log,
         mock_emit_artifact,
@@ -49,6 +53,13 @@ class TestComposeRequestOrderingOnlyDependency:
         base_context: WorkflowContext,
     ) -> None:
         """ComposeRequestStep never calls read_artifact('acceptance', ...)."""
+        from rouge.core.workflow.types import ImplementData
+
+        mock_get_affected.return_value = (
+            ["/fake/repo"],
+            ImplementData(output="done"),
+        )
+
         mock_response = Mock()
         mock_response.success = True
         mock_response.output = (
@@ -79,8 +90,10 @@ class TestComposeRequestOrderingOnlyDependency:
     @patch("rouge.core.workflow.steps.compose_request_step.emit_artifact_comment")
     @patch("rouge.core.workflow.steps.compose_request_step.log_artifact_comment_status")
     @patch("rouge.core.workflow.steps.compose_request_step.execute_template")
+    @patch("rouge.core.workflow.steps.compose_request_step.get_affected_repos")
     def test_succeeds_without_acceptance_artifact(
         self,
+        mock_get_affected,
         mock_exec,
         _mock_log,
         mock_emit_artifact,
@@ -89,6 +102,13 @@ class TestComposeRequestOrderingOnlyDependency:
         base_context: WorkflowContext,
     ) -> None:
         """ComposeRequestStep succeeds even when no acceptance artifact exists."""
+        from rouge.core.workflow.types import ImplementData
+
+        mock_get_affected.return_value = (
+            ["/fake/repo"],
+            ImplementData(output="done"),
+        )
+
         mock_response = Mock()
         mock_response.success = True
         mock_response.output = (
@@ -108,3 +128,68 @@ class TestComposeRequestOrderingOnlyDependency:
         """ComposeRequestStep is non-critical (best-effort)."""
         step = ComposeRequestStep()
         assert step.is_critical is False
+
+
+class TestComposeRequestAffectedRepos:
+    """Tests for ComposeRequestStep repo filtering behavior."""
+
+    @patch("rouge.core.workflow.steps.compose_request_step.update_status")
+    @patch("rouge.core.workflow.steps.compose_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.steps.compose_request_step.emit_artifact_comment")
+    @patch("rouge.core.workflow.steps.compose_request_step.log_artifact_comment_status")
+    @patch("rouge.core.workflow.steps.compose_request_step.execute_template")
+    @patch("rouge.core.workflow.steps.compose_request_step.get_affected_repos")
+    def test_passes_affected_repos_as_args(
+        self,
+        mock_get_affected,
+        mock_exec,
+        _mock_log,
+        mock_emit_artifact,
+        mock_emit,
+        mock_update_status,
+        base_context: WorkflowContext,
+    ) -> None:
+        """Affected repos are passed as template args."""
+        from rouge.core.workflow.types import ImplementData
+
+        mock_get_affected.return_value = (
+            ["/repo/x"],
+            ImplementData(output="done"),
+        )
+
+        mock_response = Mock()
+        mock_response.success = True
+        mock_response.output = (
+            '{"output": "pull-request", "title": "PR", "summary": "Sum", "commits": []}'
+        )
+        mock_exec.return_value = mock_response
+        mock_emit.return_value = ("success", "ok")
+        mock_emit_artifact.return_value = ("success", "ok")
+        mock_update_status.return_value = None
+
+        step = ComposeRequestStep()
+        result = step.run(base_context)
+
+        assert result.success is True
+        call_args = mock_exec.call_args[0][0]
+        assert call_args.args == ["/repo/x"]
+
+    @patch("rouge.core.workflow.steps.compose_request_step.update_status")
+    @patch("rouge.core.workflow.steps.compose_request_step.emit_comment_from_payload")
+    def test_writes_skip_artifact_when_no_affected_repos(
+        self,
+        mock_emit,
+        mock_update_status,
+        base_context: WorkflowContext,
+    ) -> None:
+        """Writes skip artifact and finalizes when no repos affected."""
+        mock_emit.return_value = ("success", "ok")
+        mock_update_status.return_value = None
+
+        step = ComposeRequestStep()
+        result = step.run(base_context)
+
+        assert result.success is True
+        artifact = base_context.artifact_store.read_artifact("compose-request")
+        assert artifact.title == "No changes"
+        assert artifact.summary == "No repos were affected by implementation"

--- a/tests/test_compose_request_step.py
+++ b/tests/test_compose_request_step.py
@@ -37,7 +37,7 @@ class TestComposeRequestOrderingOnlyDependency:
     """Tests that ComposeRequestStep does not read the acceptance artifact."""
 
     @patch("rouge.core.workflow.steps.compose_request_step.update_status")
-    @patch("rouge.core.workflow.steps.compose_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     @patch("rouge.core.workflow.steps.compose_request_step.emit_artifact_comment")
     @patch("rouge.core.workflow.steps.compose_request_step.log_artifact_comment_status")
     @patch("rouge.core.workflow.steps.compose_request_step.execute_template")
@@ -86,7 +86,7 @@ class TestComposeRequestOrderingOnlyDependency:
         assert "acceptance" not in read_calls
 
     @patch("rouge.core.workflow.steps.compose_request_step.update_status")
-    @patch("rouge.core.workflow.steps.compose_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     @patch("rouge.core.workflow.steps.compose_request_step.emit_artifact_comment")
     @patch("rouge.core.workflow.steps.compose_request_step.log_artifact_comment_status")
     @patch("rouge.core.workflow.steps.compose_request_step.execute_template")
@@ -134,7 +134,7 @@ class TestComposeRequestAffectedRepos:
     """Tests for ComposeRequestStep repo filtering behavior."""
 
     @patch("rouge.core.workflow.steps.compose_request_step.update_status")
-    @patch("rouge.core.workflow.steps.compose_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     @patch("rouge.core.workflow.steps.compose_request_step.emit_artifact_comment")
     @patch("rouge.core.workflow.steps.compose_request_step.log_artifact_comment_status")
     @patch("rouge.core.workflow.steps.compose_request_step.execute_template")
@@ -175,7 +175,7 @@ class TestComposeRequestAffectedRepos:
         assert call_args.args == ["/repo/x"]
 
     @patch("rouge.core.workflow.steps.compose_request_step.update_status")
-    @patch("rouge.core.workflow.steps.compose_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     def test_writes_skip_artifact_when_no_affected_repos(
         self,
         mock_emit,

--- a/tests/test_dependency_contracts.py
+++ b/tests/test_dependency_contracts.py
@@ -17,9 +17,11 @@ import pytest
 from rouge.core.workflow.artifacts import (
     ArtifactStore,
     ComposeRequestArtifact,
+    ImplementArtifact,
 )
 from rouge.core.workflow.step_base import WorkflowContext
 from rouge.core.workflow.step_registry import get_step_registry
+from rouge.core.workflow.types import ImplementData
 
 
 @pytest.fixture
@@ -319,6 +321,16 @@ class TestDependencySemanticsIntegration:
         mock_db_client = Mock()
         mock_get_client.return_value = mock_db_client
 
+        # Create required implement artifact
+        implement_artifact = ImplementArtifact(
+            workflow_id="test-workflow-123",
+            implement_data=ImplementData(
+                output="done",
+                affected_repos=["/fake/repo"],
+            ),
+        )
+        temp_store.write_artifact(implement_artifact)
+
         # Create optional compose-request artifact
         compose_artifact = ComposeRequestArtifact(
             workflow_id="test-workflow-123",
@@ -359,28 +371,23 @@ class TestDependencySemanticsIntegration:
         # Should succeed with artifact present
         assert result.success is True
 
-    def test_code_quality_skips_when_no_implement_artifact(
+    def test_code_quality_raises_when_no_implement_artifact(
         self, base_context: WorkflowContext
     ) -> None:
-        """CodeQualityStep succeeds with skip artifact when implement artifact is missing.
+        """CodeQualityStep raises StepInputError when implement artifact is missing.
 
-        The step now reads the implement artifact (it's a required dependency),
-        but get_affected_repos handles a missing artifact gracefully by returning
-        ([], None). The step then writes a skip artifact and returns success.
+        The implement dependency is declared as required in the step registry.
+        The pipeline framework handles non-critical steps that raise StepInputError
+        without aborting the workflow.
         """
+        import pytest
+
+        from rouge.core.workflow.step_base import StepInputError
         from rouge.core.workflow.steps.code_quality_step import CodeQualityStep
 
-        # No implement artifact is created — get_affected_repos returns ([], None)
         step = CodeQualityStep()
-        result = step.run(base_context)
-
-        # Should succeed — the step writes a skip artifact instead of running the LLM
-        assert result.success is True
-
-        # Verify a skip artifact was written
-        cq_artifact = base_context.artifact_store.read_artifact("code-quality")
-        assert cq_artifact is not None
-        assert cq_artifact.tools == ["skipped"]
+        with pytest.raises(StepInputError, match="Required artifact 'implement' not found"):
+            step.run(base_context)
 
 
 # ==============================================================================

--- a/tests/test_dependency_contracts.py
+++ b/tests/test_dependency_contracts.py
@@ -301,7 +301,7 @@ class TestDependencySemanticsIntegration:
     """Integration tests validating dependency semantics with real artifacts."""
 
     @patch("rouge.core.database.get_client")
-    @patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     def test_optional_dependency_succeeds_with_artifact(
         self,
         mock_emit: Mock,

--- a/tests/test_dependency_contracts.py
+++ b/tests/test_dependency_contracts.py
@@ -204,9 +204,8 @@ class TestOrderingOnlyDependencies:
                         select_chain.eq.return_value.execute.return_value = mock_db_response
                         update_chain = mock_db_client.table.return_value.update.return_value
                         update_chain.eq.return_value.execute.return_value = mock_db_response
-                        mock_db_client.table.return_value.insert.return_value.execute.return_value = (
-                            mock_db_response
-                        )
+                        insert_chain = mock_db_client.table.return_value.insert.return_value
+                        insert_chain.execute.return_value = mock_db_response
                         mock_client.return_value = mock_db_client
 
                         mock_response = Mock()

--- a/tests/test_dependency_contracts.py
+++ b/tests/test_dependency_contracts.py
@@ -121,7 +121,7 @@ class TestOptionalDependencies:
         # No error should be set for graceful skip
         assert result.error is None or result.error == ""
 
-    @patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     def test_optional_dependency_returns_none_not_error(
         self, mock_emit, base_context: WorkflowContext
     ) -> None:
@@ -397,9 +397,7 @@ class TestErrorMessageQuality:
         """Optional artifact skip should have informative log/comment message."""
         from rouge.core.workflow.steps.gh_pull_request_step import GhPullRequestStep
 
-        with patch(
-            "rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload"
-        ) as mock_emit:
+        with patch("rouge.core.workflow.step_utils.emit_comment_from_payload") as mock_emit:
             mock_emit.return_value = ("success", "ok")
 
             step = GhPullRequestStep()

--- a/tests/test_dependency_contracts.py
+++ b/tests/test_dependency_contracts.py
@@ -152,42 +152,6 @@ class TestOptionalDependencies:
 class TestOrderingOnlyDependencies:
     """Test that steps with ordering-only dependencies don't read artifacts."""
 
-    def test_code_quality_step_does_not_read_implement_artifact(
-        self, base_context: WorkflowContext
-    ) -> None:
-        """CodeQualityStep has ordering-only implement dependency and doesn't read it."""
-        from rouge.core.workflow.steps.code_quality_step import CodeQualityStep
-
-        # Verify registry declares implement as ordering-only
-        registry = get_step_registry()
-        metadata = registry.get_step_metadata("Running code quality checks")
-        assert metadata is not None
-        assert "implement" in metadata.dependencies
-        assert metadata.dependency_kinds.get("implement") == "ordering-only"
-
-        # Mock the artifact store's read_artifact to track calls
-        original_read = base_context.artifact_store.read_artifact
-        read_calls: list[str] = []
-
-        def tracking_read(artifact_type: str, model_class: Optional[type] = None) -> Any:
-            read_calls.append(artifact_type)
-            return original_read(artifact_type, model_class)
-
-        with patch.object(base_context.artifact_store, "read_artifact", side_effect=tracking_read):
-            # Mock the agent execution to avoid actual code quality checks
-            with patch("rouge.core.workflow.steps.code_quality_step.execute_template") as mock_exec:
-                mock_response = Mock()
-                mock_response.success = True
-                # Include at least one tool to satisfy CodeQualityArtifact validation
-                mock_response.output = '{"output": "code-quality", "tools": ["ruff"], "issues": []}'
-                mock_exec.return_value = mock_response
-
-                step = CodeQualityStep()
-                step.run(base_context)
-
-        # Assert that read_artifact was NEVER called with "implement"
-        assert "implement" not in read_calls
-
     def test_compose_request_step_does_not_read_acceptance_artifact(
         self, base_context: WorkflowContext
     ) -> None:
@@ -207,6 +171,8 @@ class TestOrderingOnlyDependencies:
             )
         assert metadata.dependency_kinds.get("acceptance") == "ordering-only"
 
+        from rouge.core.workflow.types import ImplementData
+
         # Mock the artifact store's read_artifact to track calls
         original_read = base_context.artifact_store.read_artifact
         read_calls: list[str] = []
@@ -216,35 +182,43 @@ class TestOrderingOnlyDependencies:
             return original_read(artifact_type, model_class)
 
         with patch.object(base_context.artifact_store, "read_artifact", side_effect=tracking_read):
-            # Mock the agent execution to avoid actual PR composition
+            # Mock get_affected_repos so the step doesn't skip early
             with patch(
-                "rouge.core.workflow.steps.compose_request_step.execute_template"
-            ) as mock_exec:
-                # Mock database operations to avoid database calls
-                with patch("rouge.core.database.get_client") as mock_client:
-                    # Set up mock client for database operations
-                    mock_db_client = Mock()
-                    mock_db_response = Mock()
-                    mock_db_response.data = [{"id": 42, "status": "completed"}]
-                    select_chain = mock_db_client.table.return_value.select.return_value
-                    select_chain.eq.return_value.execute.return_value = mock_db_response
-                    update_chain = mock_db_client.table.return_value.update.return_value
-                    update_chain.eq.return_value.execute.return_value = mock_db_response
-                    mock_db_client.table.return_value.insert.return_value.execute.return_value = (
-                        mock_db_response
-                    )
-                    mock_client.return_value = mock_db_client
+                "rouge.core.workflow.steps.compose_request_step.get_affected_repos"
+            ) as mock_get_affected:
+                mock_get_affected.return_value = (
+                    ["/fake/repo"],
+                    ImplementData(output="done"),
+                )
+                # Mock the agent execution to avoid actual PR composition
+                with patch(
+                    "rouge.core.workflow.steps.compose_request_step.execute_template"
+                ) as mock_exec:
+                    # Mock database operations to avoid database calls
+                    with patch("rouge.core.database.get_client") as mock_client:
+                        # Set up mock client for database operations
+                        mock_db_client = Mock()
+                        mock_db_response = Mock()
+                        mock_db_response.data = [{"id": 42, "status": "completed"}]
+                        select_chain = mock_db_client.table.return_value.select.return_value
+                        select_chain.eq.return_value.execute.return_value = mock_db_response
+                        update_chain = mock_db_client.table.return_value.update.return_value
+                        update_chain.eq.return_value.execute.return_value = mock_db_response
+                        mock_db_client.table.return_value.insert.return_value.execute.return_value = (
+                            mock_db_response
+                        )
+                        mock_client.return_value = mock_db_client
 
-                    mock_response = Mock()
-                    mock_response.success = True
-                    mock_response.output = (
-                        '{"output": "pull-request", "title": "test", '
-                        '"summary": "test summary", "commits": []}'
-                    )
-                    mock_exec.return_value = mock_response
+                        mock_response = Mock()
+                        mock_response.success = True
+                        mock_response.output = (
+                            '{"output": "pull-request", "title": "test", '
+                            '"summary": "test summary", "commits": []}'
+                        )
+                        mock_exec.return_value = mock_response
 
-                    step = ComposeRequestStep()
-                    step.run(base_context)
+                        step = ComposeRequestStep()
+                        step.run(base_context)
 
         # Assert that read_artifact was NEVER called with "acceptance"
         assert "acceptance" not in read_calls
@@ -305,7 +279,7 @@ class TestRegistryCoverage:
         test_cases = [
             ("Implementing solution", ["plan"]),
             ("Running code quality checks", ["implement"]),
-            ("Creating GitHub pull request", ["compose-request"]),
+            ("Creating GitHub pull request", ["implement", "compose-request"]),
         ]
 
         for step_name, expected_deps in test_cases:
@@ -362,12 +336,23 @@ class TestDependencySemanticsIntegration:
                     "rouge.core.workflow.steps.gh_pull_request_step.subprocess.run"
                 ) as mock_run:
                     mock_which.return_value = "/usr/bin/gh"
-                    # New step makes 4 calls per repo: rev-parse, gh pr list, git push, gh pr create
+                    # Step makes 6 calls per repo:
+                    # rev-parse (branch), gh pr list, origin/HEAD check,
+                    # rev-list (ahead count), git push, gh pr create
                     mock_rev_parse = Mock(returncode=0, stdout="feature-branch\n", stderr="")
                     mock_pr_list = Mock(returncode=0, stdout="[]", stderr="")
+                    mock_origin_head = Mock(returncode=0, stdout="abc123\n", stderr="")
+                    mock_rev_list = Mock(returncode=0, stdout="3\n", stderr="")
                     mock_push = Mock(returncode=0, stdout="", stderr="")
                     mock_pr = Mock(returncode=0, stdout="https://github.com/test/pr/1\n")
-                    mock_run.side_effect = [mock_rev_parse, mock_pr_list, mock_push, mock_pr]
+                    mock_run.side_effect = [
+                        mock_rev_parse,
+                        mock_pr_list,
+                        mock_origin_head,
+                        mock_rev_list,
+                        mock_push,
+                        mock_pr,
+                    ]
 
                     step = GhPullRequestStep()
                     result = step.run(base_context)
@@ -375,28 +360,28 @@ class TestDependencySemanticsIntegration:
         # Should succeed with artifact present
         assert result.success is True
 
-    def test_ordering_only_dependency_works_without_reading(
+    def test_code_quality_skips_when_no_implement_artifact(
         self, base_context: WorkflowContext
     ) -> None:
-        """Ordering-only dependency step succeeds without reading the dependency artifact."""
+        """CodeQualityStep succeeds with skip artifact when implement artifact is missing.
+
+        The step now reads the implement artifact (it's a required dependency),
+        but get_affected_repos handles a missing artifact gracefully by returning
+        ([], None). The step then writes a skip artifact and returns success.
+        """
         from rouge.core.workflow.steps.code_quality_step import CodeQualityStep
 
-        # Note: No implement artifact is created, but step should not fail because of that
-        # The step only needs ordering (implement must run first), not the artifact data
+        # No implement artifact is created — get_affected_repos returns ([], None)
+        step = CodeQualityStep()
+        result = step.run(base_context)
 
-        # Mock agent execution
-        with patch("rouge.core.workflow.steps.code_quality_step.execute_template") as mock_exec:
-            mock_response = Mock()
-            mock_response.success = True
-            # Include at least one tool to satisfy CodeQualityArtifact validation
-            mock_response.output = '{"output": "code-quality", "tools": ["ruff"], "issues": []}'
-            mock_exec.return_value = mock_response
-
-            step = CodeQualityStep()
-            result = step.run(base_context)
-
-        # Should succeed even without implement artifact (ordering-only doesn't read it)
+        # Should succeed — the step writes a skip artifact instead of running the LLM
         assert result.success is True
+
+        # Verify a skip artifact was written
+        cq_artifact = base_context.artifact_store.read_artifact("code-quality")
+        assert cq_artifact is not None
+        assert cq_artifact.tools == ["skipped"]
 
 
 # ==============================================================================

--- a/tests/test_gh_pull_request_step.py
+++ b/tests/test_gh_pull_request_step.py
@@ -6,6 +6,7 @@ Focuses on:
 - Loading PR details from artifact when present
 """
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -76,7 +77,7 @@ class TestGhPullRequestStepOptionalDependency:
         read_calls: list[str] = []
         original_read = store.read_artifact
 
-        def tracking_read(artifact_type, model_class=None):
+        def tracking_read(artifact_type: str, model_class: Any = None) -> Any:
             read_calls.append(artifact_type)
             return original_read(artifact_type, model_class)
 

--- a/tests/test_gh_pull_request_step.py
+++ b/tests/test_gh_pull_request_step.py
@@ -35,7 +35,7 @@ def base_context(store: ArtifactStore) -> WorkflowContext:
 class TestGhPullRequestStepOptionalDependency:
     """Tests verifying GhPullRequestStep handles absent compose-request artifact gracefully."""
 
-    @patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     def test_succeeds_when_compose_request_artifact_absent(
         self, mock_emit, base_context: WorkflowContext
     ) -> None:
@@ -49,7 +49,7 @@ class TestGhPullRequestStepOptionalDependency:
         assert result.success is True
         assert result.error is None
 
-    @patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     def test_emits_skip_comment_when_artifact_absent(
         self, mock_emit, base_context: WorkflowContext
     ) -> None:
@@ -65,7 +65,7 @@ class TestGhPullRequestStepOptionalDependency:
         # Message should indicate skip reason
         assert "skip" in payload.text.lower() or "no pr details" in payload.text.lower()
 
-    @patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     def test_loads_pr_details_via_optional_artifact(
         self, mock_emit, base_context: WorkflowContext, store: ArtifactStore
     ) -> None:
@@ -88,7 +88,7 @@ class TestGhPullRequestStepOptionalDependency:
         # Artifact loading was attempted for compose-request
         assert "compose-request" in read_calls
 
-    @patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     def test_does_not_raise_when_artifact_absent(
         self, mock_emit, base_context: WorkflowContext
     ) -> None:
@@ -104,7 +104,7 @@ class TestGhPullRequestStepOptionalDependency:
 class TestGhPullRequestStepWithArtifact:
     """Tests verifying GhPullRequestStep uses compose-request artifact when present."""
 
-    @patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     @patch("rouge.core.workflow.steps.gh_pull_request_step.emit_artifact_comment")
     @patch("rouge.core.workflow.steps.gh_pull_request_step.log_artifact_comment_status")
     @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")

--- a/tests/test_implement_step.py
+++ b/tests/test_implement_step.py
@@ -22,6 +22,7 @@ def mock_context():
     context.adw_id = "test-adw-impl"
     context.data = {}
     context.artifact_store = Mock()
+    context.repo_paths = []
     return context
 
 

--- a/tests/test_implement_step.py
+++ b/tests/test_implement_step.py
@@ -205,9 +205,7 @@ class TestImplementStepRerunBehavior:
         mock_context.artifact_store.artifact_exists.return_value = False
 
         with patch.object(ImplementStep, "_implement_plan") as mock_impl:
-            with patch(
-                "rouge.core.workflow.step_utils.emit_comment_from_payload"
-            ) as mock_e:
+            with patch("rouge.core.workflow.step_utils.emit_comment_from_payload") as mock_e:
                 with patch(
                     "rouge.core.workflow.steps.implement_step.emit_artifact_comment"
                 ) as mock_emit_artifact:

--- a/tests/test_implement_step.py
+++ b/tests/test_implement_step.py
@@ -14,7 +14,7 @@ from rouge.core.workflow.types import (
 
 
 @pytest.fixture
-def mock_context():
+def mock_context() -> WorkflowContext:
     """Create a mock workflow context."""
     context = Mock(spec=WorkflowContext)
     context.issue_id = 10

--- a/tests/test_implement_step.py
+++ b/tests/test_implement_step.py
@@ -45,7 +45,7 @@ def mock_load_required_artifact(mock_context) -> WorkflowContext:
 
 
 @pytest.fixture
-def sample_plan_data():
+def sample_plan_data() -> PlanData:
     """Create a sample PlanData."""
     return PlanData(
         plan="## Plan\n\n### Step 1\nImplement feature X",
@@ -55,7 +55,7 @@ def sample_plan_data():
 
 
 @pytest.fixture
-def sample_implement_data():
+def sample_implement_data() -> ImplementData:
     """Create a sample ImplementData."""
     return ImplementData(
         output="Implementation completed successfully. Files modified: README.md",
@@ -67,7 +67,7 @@ class TestImplementStepRun:
     """Tests for ImplementStep.run method."""
 
     @patch("rouge.core.workflow.steps.implement_step.emit_artifact_comment")
-    @patch("rouge.core.workflow.steps.implement_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     @patch.object(ImplementStep, "_implement_plan")
     def test_run_success_with_plan(
         self,
@@ -108,7 +108,7 @@ class TestImplementStepRun:
         assert result.success is False
         assert "no plan available" in result.error
 
-    @patch("rouge.core.workflow.steps.implement_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     @patch.object(ImplementStep, "_implement_plan")
     def test_run_fails_when__implement_plan_fails(
         self,
@@ -132,7 +132,7 @@ class TestImplementStepRun:
         _mock_emit.assert_not_called()
 
     @patch("rouge.core.workflow.steps.implement_step.emit_artifact_comment")
-    @patch("rouge.core.workflow.steps.implement_step.emit_comment_from_payload")
+    @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
     @patch.object(ImplementStep, "_implement_plan")
     def test_run_saves_artifact(
         self,
@@ -206,7 +206,7 @@ class TestImplementStepRerunBehavior:
 
         with patch.object(ImplementStep, "_implement_plan") as mock_impl:
             with patch(
-                "rouge.core.workflow.steps.implement_step.emit_comment_from_payload"
+                "rouge.core.workflow.step_utils.emit_comment_from_payload"
             ) as mock_e:
                 with patch(
                     "rouge.core.workflow.steps.implement_step.emit_artifact_comment"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -372,9 +372,9 @@ class TestPromptRegistryRender:
     def test_render_no_arguments_placeholder_empty_args_no_append(self) -> None:
         """Templates without $ARGUMENTS and empty args produce clean body."""
         registry = PromptRegistry()
-        result = registry.render(PromptId.CODE_QUALITY, [])
+        result = registry.render(PromptId.PULL_REQUEST, [])
         # body unchanged, no trailing whitespace artifact
-        template = registry.get(PromptId.CODE_QUALITY)
+        template = registry.get(PromptId.PULL_REQUEST)
         assert result.text == template.body
 
     def test_render_returns_model_from_template(self) -> None:

--- a/tests/test_repo_filter.py
+++ b/tests/test_repo_filter.py
@@ -73,7 +73,7 @@ class TestGetAffectedRepos:
         assert data is not None
 
     def test_warns_on_unknown_repos(
-        self, base_context: WorkflowContext, store: ArtifactStore, caplog
+        self, base_context: WorkflowContext, store: ArtifactStore, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Logs warning when affected_repos contains paths not in context.repo_paths."""
         implement_data = ImplementData(

--- a/tests/test_repo_filter.py
+++ b/tests/test_repo_filter.py
@@ -1,7 +1,6 @@
 """Tests for repo_filter shared helper."""
 
 from pathlib import Path
-from unittest.mock import Mock
 
 import pytest
 

--- a/tests/test_repo_filter.py
+++ b/tests/test_repo_filter.py
@@ -6,7 +6,7 @@ import pytest
 
 from rouge.core.workflow.artifacts import ArtifactStore, ImplementArtifact
 from rouge.core.workflow.repo_filter import get_affected_repos
-from rouge.core.workflow.step_base import WorkflowContext
+from rouge.core.workflow.step_base import StepInputError, WorkflowContext
 from rouge.core.workflow.types import ImplementData
 
 
@@ -30,11 +30,10 @@ def base_context(store: ArtifactStore) -> WorkflowContext:
 class TestGetAffectedRepos:
     """Tests for get_affected_repos helper."""
 
-    def test_returns_empty_when_no_implement_artifact(self, base_context: WorkflowContext) -> None:
-        """Returns empty list and None when implement artifact is missing."""
-        repos, data = get_affected_repos(base_context)
-        assert repos == []
-        assert data is None
+    def test_raises_when_no_implement_artifact(self, base_context: WorkflowContext) -> None:
+        """Raises StepInputError when implement artifact is missing."""
+        with pytest.raises(StepInputError, match="Required artifact 'implement' not found"):
+            get_affected_repos(base_context)
 
     def test_returns_filtered_repos_in_order(
         self, base_context: WorkflowContext, store: ArtifactStore

--- a/tests/test_repo_filter.py
+++ b/tests/test_repo_filter.py
@@ -1,0 +1,117 @@
+"""Tests for repo_filter shared helper."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from rouge.core.workflow.artifacts import ArtifactStore, ImplementArtifact
+from rouge.core.workflow.repo_filter import get_affected_repos
+from rouge.core.workflow.step_base import WorkflowContext
+from rouge.core.workflow.types import ImplementData
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> ArtifactStore:
+    """Create a temporary artifact store."""
+    return ArtifactStore(workflow_id="test-repo-filter", base_path=tmp_path)
+
+
+@pytest.fixture
+def base_context(store: ArtifactStore) -> WorkflowContext:
+    """Create a workflow context with multiple repo paths."""
+    return WorkflowContext(
+        adw_id="test-repo-filter",
+        issue_id=99,
+        artifact_store=store,
+        repo_paths=["/repo/alpha", "/repo/beta", "/repo/gamma"],
+    )
+
+
+class TestGetAffectedRepos:
+    """Tests for get_affected_repos helper."""
+
+    def test_returns_empty_when_no_implement_artifact(self, base_context: WorkflowContext) -> None:
+        """Returns empty list and None when implement artifact is missing."""
+        repos, data = get_affected_repos(base_context)
+        assert repos == []
+        assert data is None
+
+    def test_returns_filtered_repos_in_order(
+        self, base_context: WorkflowContext, store: ArtifactStore
+    ) -> None:
+        """Returns only affected repos, preserving context.repo_paths order."""
+        implement_data = ImplementData(
+            output="done",
+            affected_repos=["/repo/gamma", "/repo/alpha"],
+        )
+        artifact = ImplementArtifact(
+            workflow_id="test-repo-filter",
+            implement_data=implement_data,
+        )
+        store.write_artifact(artifact)
+
+        repos, data = get_affected_repos(base_context)
+
+        # Should be in context.repo_paths order, not affected_repos order
+        assert repos == ["/repo/alpha", "/repo/gamma"]
+        assert data is not None
+        assert data.affected_repos == ["/repo/gamma", "/repo/alpha"]
+
+    def test_returns_empty_when_no_repos_affected(
+        self, base_context: WorkflowContext, store: ArtifactStore
+    ) -> None:
+        """Returns empty list when affected_repos is empty."""
+        implement_data = ImplementData(output="done", affected_repos=[])
+        artifact = ImplementArtifact(
+            workflow_id="test-repo-filter",
+            implement_data=implement_data,
+        )
+        store.write_artifact(artifact)
+
+        repos, data = get_affected_repos(base_context)
+        assert repos == []
+        assert data is not None
+
+    def test_warns_on_unknown_repos(
+        self, base_context: WorkflowContext, store: ArtifactStore, caplog
+    ) -> None:
+        """Logs warning when affected_repos contains paths not in context.repo_paths."""
+        implement_data = ImplementData(
+            output="done",
+            affected_repos=["/repo/alpha", "/repo/unknown"],
+        )
+        artifact = ImplementArtifact(
+            workflow_id="test-repo-filter",
+            implement_data=implement_data,
+        )
+        store.write_artifact(artifact)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            repos, data = get_affected_repos(base_context)
+
+        assert repos == ["/repo/alpha"]
+        assert "/repo/unknown" in caplog.text or any("unknown" in r.message for r in caplog.records)
+
+    def test_single_repo_all_affected(self, store: ArtifactStore) -> None:
+        """Single repo context with that repo affected returns it."""
+        context = WorkflowContext(
+            adw_id="test-repo-filter",
+            issue_id=99,
+            artifact_store=store,
+            repo_paths=["/repo/only"],
+        )
+        implement_data = ImplementData(
+            output="done",
+            affected_repos=["/repo/only"],
+        )
+        artifact = ImplementArtifact(
+            workflow_id="test-repo-filter",
+            implement_data=implement_data,
+        )
+        store.write_artifact(artifact)
+
+        repos, data = get_affected_repos(context)
+        assert repos == ["/repo/only"]

--- a/tests/test_step_registry.py
+++ b/tests/test_step_registry.py
@@ -810,36 +810,51 @@ class TestRegistryContractConstraints:
         """Steps with optional/ordering-only deps must have them explicitly declared.
 
         Policy assertions:
-        - gh-pull-request and glab-pull-request declare compose-request as optional
-        - code-quality declares implement as ordering-only
-        - compose-request declares implement as ordering-only
+        - gh-pull-request declares compose-request and implement as optional
+        - glab-pull-request declares compose-request and implement as optional
+        - code-quality declares implement as required (no dependency_kinds entry)
+        - compose-request declares implement as required (no dependency_kinds entry)
         """
         registry = get_step_registry()
 
-        # gh-pull-request: compose-request is optional
+        # gh-pull-request: compose-request and implement are optional
         gh_meta = registry.get_step_metadata_by_slug("gh-pull-request")
         assert gh_meta is not None, "gh-pull-request step must be registered"
         assert (
             gh_meta.dependency_kinds.get("compose-request") == "optional"
         ), "gh-pull-request must declare compose-request as optional"
+        assert (
+            gh_meta.dependency_kinds.get("implement") == "optional"
+        ), "gh-pull-request must declare implement as optional"
 
-        # glab-pull-request: compose-request is optional
+        # glab-pull-request: compose-request and implement are optional
         glab_meta = registry.get_step_metadata_by_slug("glab-pull-request")
         assert glab_meta is not None, "glab-pull-request step must be registered"
         assert (
             glab_meta.dependency_kinds.get("compose-request") == "optional"
         ), "glab-pull-request must declare compose-request as optional"
+        assert (
+            glab_meta.dependency_kinds.get("implement") == "optional"
+        ), "glab-pull-request must declare implement as optional"
 
-        # code-quality: implement is ordering-only
+        # code-quality: implement is now required (no dependency_kinds entry)
         cq_meta = registry.get_step_metadata_by_slug("code-quality")
         assert cq_meta is not None, "code-quality step must be registered"
         assert (
-            cq_meta.dependency_kinds.get("implement") == "ordering-only"
-        ), "code-quality must declare implement as ordering-only"
+            "implement" in cq_meta.dependencies
+        ), "code-quality must declare implement as a dependency"
+        assert "implement" not in cq_meta.dependency_kinds, (
+            "code-quality implement dependency should be implicitly required "
+            "(not listed in dependency_kinds)"
+        )
 
-        # compose-request: implement is ordering-only
+        # compose-request: implement is now required (no dependency_kinds entry)
         cr_meta = registry.get_step_metadata_by_slug("compose-request")
         assert cr_meta is not None, "compose-request step must be registered"
         assert (
-            cr_meta.dependency_kinds.get("implement") == "ordering-only"
-        ), "compose-request must declare implement as ordering-only"
+            "implement" in cr_meta.dependencies
+        ), "compose-request must declare implement as a dependency"
+        assert "implement" not in cr_meta.dependency_kinds, (
+            "compose-request implement dependency should be implicitly required "
+            "(not listed in dependency_kinds)"
+        )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -205,7 +205,7 @@ def test_code_quality_step_passes_json_schema(mock_execute, mock_emit, mock_get_
 
 @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
 @patch("rouge.core.workflow.steps.gh_pull_request_step.subprocess.run")
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_success(mock_emit, mock_subprocess, mock_which) -> None:
     """Test successful PR creation: rev-parse, pr list (empty), push, pr create."""
@@ -350,7 +350,7 @@ def test_create_pr_step_empty_title(mock_emit) -> None:
 
 
 @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.gh_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_already_exists_is_success(mock_subprocess, mock_emit, mock_which) -> None:
@@ -394,7 +394,7 @@ def test_create_pr_step_already_exists_is_success(mock_subprocess, mock_emit, mo
 
 
 @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.gh_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_gh_command_failure(mock_subprocess, mock_emit, mock_which) -> None:
@@ -446,7 +446,7 @@ def test_create_pr_step_gh_command_failure(mock_subprocess, mock_emit, mock_whic
 
 
 @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.gh_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_timeout(mock_subprocess, mock_emit, mock_which) -> None:
@@ -526,7 +526,7 @@ def test_create_pr_step_gh_not_found(mock_emit, mock_which) -> None:
 
 
 @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.gh_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_push_failure_continues_to_pr(
@@ -581,7 +581,7 @@ def test_create_pr_step_push_failure_continues_to_pr(
 
 
 @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.gh_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_push_timeout_continues_to_pr(
@@ -637,7 +637,7 @@ def test_create_pr_step_push_timeout_continues_to_pr(
 
 @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
 @patch("rouge.core.workflow.steps.gh_pull_request_step.subprocess.run")
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_multi_repo_success(mock_emit, mock_subprocess, mock_which) -> None:
     """Test successful PR creation across two repos: subprocess invoked once per repo."""
@@ -727,7 +727,7 @@ def test_create_pr_step_multi_repo_success(mock_emit, mock_subprocess, mock_whic
 
 @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
 @patch("rouge.core.workflow.steps.gh_pull_request_step.subprocess.run")
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_multi_repo_failure(mock_emit, mock_subprocess, mock_which) -> None:
     """Test PR creation with both repos failing: subprocess invoked once per repo,
@@ -1297,7 +1297,7 @@ def test_prepare_pr_step_store_pr_details_missing_fields() -> None:
 
 
 @patch("rouge.core.workflow.steps.compose_request_step.get_affected_repos")
-@patch("rouge.core.workflow.steps.compose_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.compose_request_step.execute_template")
 @patch("rouge.core.workflow.steps.compose_request_step.update_status")
 def test_prepare_pr_step_emits_raw_llm_response(

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -175,7 +175,7 @@ def test_execute_workflow_second_step_failure(mock_get_pipeline) -> None:
 
 
 @patch("rouge.core.workflow.steps.code_quality_step.get_affected_repos")
-@patch("rouge.core.workflow.steps.code_quality_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.code_quality_step.execute_template")
 def test_code_quality_step_passes_json_schema(mock_execute, mock_emit, mock_get_affected) -> None:
     """Test code quality step passes strict JSON schema to Claude template request."""
@@ -1048,7 +1048,9 @@ def test_create_gitlab_mr_step_glab_command_failure(
 @patch("rouge.core.workflow.steps.glab_pull_request_step.get_logger")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITLAB_PAT": "test-token"})
-def test_create_gitlab_mr_step_timeout(mock_subprocess, mock_get_logger, mock_emit, mock_which) -> None:
+def test_create_gitlab_mr_step_timeout(
+    mock_subprocess, mock_get_logger, mock_emit, mock_which
+) -> None:
     """Test MR creation handles timeout on glab mr create (caught per-repo, step continues)."""
     import subprocess
 
@@ -1102,7 +1104,9 @@ def test_create_gitlab_mr_step_timeout(mock_subprocess, mock_get_logger, mock_em
 @patch("rouge.core.workflow.steps.glab_pull_request_step.get_logger")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITLAB_PAT": "test-token"})
-def test_create_gitlab_mr_step_glab_not_found(mock_subprocess, mock_get_logger, mock_emit, mock_which) -> None:
+def test_create_gitlab_mr_step_glab_not_found(
+    mock_subprocess, mock_get_logger, mock_emit, mock_which
+) -> None:
     """Test MR creation handles glab CLI not found (propagates to outer
     FileNotFoundError handler)."""
 
@@ -1149,7 +1153,9 @@ def test_create_gitlab_mr_step_glab_not_found(mock_subprocess, mock_get_logger, 
 @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITLAB_PAT": "test-token"})
-def test_create_gitlab_mr_step_push_failure_continues_to_mr(mock_subprocess, mock_emit, mock_which) -> None:
+def test_create_gitlab_mr_step_push_failure_continues_to_mr(
+    mock_subprocess, mock_emit, mock_which
+) -> None:
     """Test MR creation continues even when git push fails."""
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
@@ -1200,7 +1206,9 @@ def test_create_gitlab_mr_step_push_failure_continues_to_mr(mock_subprocess, moc
 @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITLAB_PAT": "test-token"})
-def test_create_gitlab_mr_step_push_timeout_continues_to_mr(mock_subprocess, mock_emit, mock_which) -> None:
+def test_create_gitlab_mr_step_push_timeout_continues_to_mr(
+    mock_subprocess, mock_emit, mock_which
+) -> None:
     """Test MR creation continues even when git push times out."""
     import subprocess
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -9,9 +9,9 @@ import pytest
 from rouge.core.models import CommentPayload, Issue
 from rouge.core.notifications.comments import emit_comment_from_payload
 from rouge.core.workflow import execute_workflow, update_status
-from rouge.core.workflow.artifacts import ArtifactStore
+from rouge.core.workflow.artifacts import ArtifactStore, ImplementArtifact
 from rouge.core.workflow.step_base import WorkflowContext
-from rouge.core.workflow.types import StepResult
+from rouge.core.workflow.types import ImplementData, StepResult
 
 
 def _make_context(adw_id: str = "adw123", issue_id: int = 1, **kwargs) -> WorkflowContext:
@@ -22,6 +22,18 @@ def _make_context(adw_id: str = "adw123", issue_id: int = 1, **kwargs) -> Workfl
     context = WorkflowContext(issue_id=issue_id, adw_id=adw_id, artifact_store=store, **kwargs)
     context._tmp_dir = tmp_dir  # type: ignore[attr-defined]  # keeps dir alive until context is GC'd
     return context
+
+
+def _write_implement_artifact(
+    context: WorkflowContext, repo_paths: list[str] | None = None
+) -> None:
+    """Write an implement artifact so PR steps iterate the given repos."""
+    affected = repo_paths if repo_paths is not None else context.repo_paths
+    artifact = ImplementArtifact(
+        workflow_id=context.adw_id,
+        implement_data=ImplementData(output="done", affected_repos=affected),
+    )
+    context.artifact_store.write_artifact(artifact)
 
 
 @pytest.fixture
@@ -228,6 +240,7 @@ def test_create_pr_step_success(mock_emit, mock_subprocess, mock_which) -> None:
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This PR adds a new feature.",
@@ -261,7 +274,7 @@ def test_create_pr_step_success(mock_emit, mock_subprocess, mock_which) -> None:
 
 
 @patch.dict("os.environ", {}, clear=True)
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 def test_create_pr_step_missing_github_pat(mock_emit) -> None:
     """Test PR creation skipped when GITHUB_PAT is missing."""
 
@@ -287,7 +300,7 @@ def test_create_pr_step_missing_github_pat(mock_emit) -> None:
     assert mock_emit.call_args[0][0].raw["output"] == "pull-request-skipped"
 
 
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 def test_create_pr_step_missing_pr_details(mock_emit) -> None:
     """Test PR creation skipped when pr_details is missing."""
 
@@ -309,7 +322,7 @@ def test_create_pr_step_missing_pr_details(mock_emit) -> None:
     assert mock_emit.call_args[0][0].raw["output"] == "pull-request-skipped"
 
 
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_empty_title(mock_emit) -> None:
     """Test PR creation skipped when title is empty."""
@@ -362,6 +375,7 @@ def test_create_pr_step_already_exists_is_success(mock_subprocess, mock_emit, mo
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This PR adds a new feature.",
@@ -414,6 +428,7 @@ def test_create_pr_step_gh_command_failure(mock_subprocess, mock_emit, mock_whic
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This PR adds a new feature.",
@@ -461,6 +476,7 @@ def test_create_pr_step_timeout(mock_subprocess, mock_emit, mock_which) -> None:
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This PR adds a new feature.",
@@ -476,7 +492,7 @@ def test_create_pr_step_timeout(mock_subprocess, mock_emit, mock_which) -> None:
 
 
 @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
-@patch("rouge.core.workflow.steps.gh_pull_request_step.emit_comment_from_payload")
+@patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_gh_not_found(mock_emit, mock_which) -> None:
     """Test PR creation handles gh CLI not found via proactive detection."""
@@ -547,6 +563,7 @@ def test_create_pr_step_push_failure_continues_to_pr(
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This PR adds a new feature.",
@@ -601,6 +618,7 @@ def test_create_pr_step_push_timeout_continues_to_pr(
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This PR adds a new feature.",
@@ -665,6 +683,7 @@ def test_create_pr_step_multi_repo_success(mock_emit, mock_subprocess, mock_whic
     ]
 
     context = _make_context(repo_paths=["/repo/a", "/repo/b"])
+    _write_implement_artifact(context, ["/repo/a", "/repo/b"])
     context.data["pr_details"] = {
         "title": "feat: multi-repo feature",
         "summary": "This PR spans two repos.",
@@ -751,6 +770,7 @@ def test_create_pr_step_multi_repo_failure(mock_emit, mock_subprocess, mock_whic
     ]
 
     context = _make_context(repo_paths=["/repo/a", "/repo/b"])
+    _write_implement_artifact(context, ["/repo/a", "/repo/b"])
     context.data["pr_details"] = {
         "title": "feat: multi-repo feature",
         "summary": "This PR spans two repos.",
@@ -842,6 +862,7 @@ def test_create_gitlab_mr_step_success(mock_emit, mock_subprocess) -> None:
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This MR adds a new feature.",
@@ -1001,6 +1022,7 @@ def test_create_gitlab_mr_step_glab_command_failure(
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This MR adds a new feature.",
@@ -1052,6 +1074,7 @@ def test_create_gitlab_mr_step_timeout(mock_subprocess, mock_get_logger, mock_em
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This MR adds a new feature.",
@@ -1098,6 +1121,7 @@ def test_create_gitlab_mr_step_glab_not_found(mock_subprocess, mock_get_logger, 
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This MR adds a new feature.",
@@ -1145,6 +1169,7 @@ def test_create_gitlab_mr_step_push_failure_continues_to_mr(mock_subprocess, moc
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This MR adds a new feature.",
@@ -1193,6 +1218,7 @@ def test_create_gitlab_mr_step_push_timeout_continues_to_mr(mock_subprocess, moc
     mock_emit.return_value = ("success", "Comment inserted")
 
     context = _make_context()
+    _write_implement_artifact(context)
     context.data["pr_details"] = {
         "title": "feat: add new feature",
         "summary": "This MR adds a new feature.",

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -831,14 +831,16 @@ def test_create_pr_step_name() -> None:
 # === GlabPullRequestStep Tests ===
 
 
+@patch("rouge.core.workflow.steps.glab_pull_request_step.shutil.which")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.subprocess.run")
 @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch.dict("os.environ", {"GITLAB_PAT": "test-token"})
-def test_create_gitlab_mr_step_success(mock_emit, mock_subprocess) -> None:
+def test_create_gitlab_mr_step_success(mock_emit, mock_subprocess, mock_which) -> None:
     """Test successful MR creation: rev-parse, mr list (empty), push, mr create."""
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
+    mock_which.return_value = "/usr/bin/glab"
     # Step calls: git rev-parse, glab mr list (empty), delta check (2), git push, glab mr create
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_mr_list = Mock(returncode=0, stdout="[]", stderr="")
@@ -985,17 +987,19 @@ def test_create_gitlab_mr_step_empty_title(mock_get_logger, mock_emit) -> None:
     assert mock_emit.call_args[0][0].raw["output"] == "merge-request-skipped"
 
 
+@patch("rouge.core.workflow.steps.glab_pull_request_step.shutil.which")
 @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.get_logger")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITLAB_PAT": "test-token"})
 def test_create_gitlab_mr_step_glab_command_failure(
-    mock_subprocess, mock_get_logger, mock_emit
+    mock_subprocess, mock_get_logger, mock_emit, mock_which
 ) -> None:
     """Test MR creation handles glab command failure (best-effort: returns success)."""
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
+    mock_which.return_value = "/usr/bin/glab"
     # Mock the logger instance returned by get_logger
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
@@ -1039,16 +1043,18 @@ def test_create_gitlab_mr_step_glab_command_failure(
     assert mock_emit.call_args[0][0].raw["output"] == "merge-request-failed"
 
 
+@patch("rouge.core.workflow.steps.glab_pull_request_step.shutil.which")
 @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.get_logger")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITLAB_PAT": "test-token"})
-def test_create_gitlab_mr_step_timeout(mock_subprocess, mock_get_logger, mock_emit) -> None:
+def test_create_gitlab_mr_step_timeout(mock_subprocess, mock_get_logger, mock_emit, mock_which) -> None:
     """Test MR creation handles timeout on glab mr create (caught per-repo, step continues)."""
     import subprocess
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
+    mock_which.return_value = "/usr/bin/glab"
     # Mock the logger instance returned by get_logger
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
@@ -1091,16 +1097,18 @@ def test_create_gitlab_mr_step_timeout(mock_subprocess, mock_get_logger, mock_em
     assert mock_emit.call_args[0][0].raw["output"] == "merge-request-failed"
 
 
+@patch("rouge.core.workflow.steps.glab_pull_request_step.shutil.which")
 @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.get_logger")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITLAB_PAT": "test-token"})
-def test_create_gitlab_mr_step_glab_not_found(mock_subprocess, mock_get_logger, mock_emit) -> None:
+def test_create_gitlab_mr_step_glab_not_found(mock_subprocess, mock_get_logger, mock_emit, mock_which) -> None:
     """Test MR creation handles glab CLI not found (propagates to outer
     FileNotFoundError handler)."""
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
+    mock_which.return_value = "/usr/bin/glab"
     # Mock the logger instance returned by get_logger
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
@@ -1137,14 +1145,16 @@ def test_create_gitlab_mr_step_glab_not_found(mock_subprocess, mock_get_logger, 
     assert mock_emit.call_args[0][0].raw["output"] == "merge-request-failed"
 
 
+@patch("rouge.core.workflow.steps.glab_pull_request_step.shutil.which")
 @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITLAB_PAT": "test-token"})
-def test_create_gitlab_mr_step_push_failure_continues_to_mr(mock_subprocess, mock_emit) -> None:
+def test_create_gitlab_mr_step_push_failure_continues_to_mr(mock_subprocess, mock_emit, mock_which) -> None:
     """Test MR creation continues even when git push fails."""
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
+    mock_which.return_value = "/usr/bin/glab"
     # Step calls: rev-parse, mr list (empty), delta check (2),
     # push (failure → best-effort), glab mr create (success)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
@@ -1186,15 +1196,17 @@ def test_create_gitlab_mr_step_push_failure_continues_to_mr(mock_subprocess, moc
     assert mock_emit.call_args[0][0].raw["output"] == "merge-request-created"
 
 
+@patch("rouge.core.workflow.steps.glab_pull_request_step.shutil.which")
 @patch("rouge.core.workflow.step_utils.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.glab_pull_request_step.subprocess.run")
 @patch.dict("os.environ", {"GITLAB_PAT": "test-token"})
-def test_create_gitlab_mr_step_push_timeout_continues_to_mr(mock_subprocess, mock_emit) -> None:
+def test_create_gitlab_mr_step_push_timeout_continues_to_mr(mock_subprocess, mock_emit, mock_which) -> None:
     """Test MR creation continues even when git push times out."""
     import subprocess
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
+    mock_which.return_value = "/usr/bin/glab"
     # Step calls: rev-parse, mr list (empty), delta check (2),
     # push (timeout → best-effort), glab mr create (success)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -162,12 +162,14 @@ def test_execute_workflow_second_step_failure(mock_get_pipeline) -> None:
     assert result is False
 
 
+@patch("rouge.core.workflow.steps.code_quality_step.get_affected_repos")
 @patch("rouge.core.workflow.steps.code_quality_step.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.code_quality_step.execute_template")
-def test_code_quality_step_passes_json_schema(mock_execute, mock_emit) -> None:
+def test_code_quality_step_passes_json_schema(mock_execute, mock_emit, mock_get_affected) -> None:
     """Test code quality step passes strict JSON schema to Claude template request."""
 
     from rouge.core.workflow.steps.code_quality_step import CodeQualityStep
+    from rouge.core.workflow.types import ImplementData
 
     mock_emit.return_value = ("success", "ok")
     mock_response = Mock()
@@ -176,6 +178,7 @@ def test_code_quality_step_passes_json_schema(mock_execute, mock_emit) -> None:
     mock_execute.return_value = mock_response
 
     context = _make_context()
+    mock_get_affected.return_value = (context.repo_paths, ImplementData(output="done"))
     step = CodeQualityStep()
     result = step.run(context)
 
@@ -202,15 +205,24 @@ def test_create_pr_step_success(mock_emit, mock_subprocess, mock_which) -> None:
     # Mock shutil.which to indicate gh CLI is available
     mock_which.return_value = "/usr/bin/gh"
 
-    # Step calls: git rev-parse, gh pr list (empty), git push, gh pr create
+    # Step calls: git rev-parse, gh pr list (empty), delta check (2), git push, gh pr create
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_pr_list = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count = Mock(returncode=0, stdout="1\n", stderr="")
     mock_push_result = Mock(returncode=0, stdout="", stderr="")
     mock_pr_result = Mock(
         returncode=0, stdout="https://github.com/owner/repo/pull/123\n", stderr=""
     )
 
-    mock_subprocess.side_effect = [mock_rev_parse, mock_pr_list, mock_push_result, mock_pr_result]
+    mock_subprocess.side_effect = [
+        mock_rev_parse,
+        mock_pr_list,
+        mock_base_check,
+        mock_ahead_count,
+        mock_push_result,
+        mock_pr_result,
+    ]
 
     # Mock emit_comment_from_payload success
     mock_emit.return_value = ("success", "Comment inserted")
@@ -226,16 +238,16 @@ def test_create_pr_step_success(mock_emit, mock_subprocess, mock_which) -> None:
     result = step.run(context)
 
     assert result.success is True
-    assert mock_subprocess.call_count == 4
+    assert mock_subprocess.call_count == 6
     mock_emit.assert_called_once()
 
-    # Verify git push was called third
-    push_call = mock_subprocess.call_args_list[2]
+    # Verify git push was called fifth
+    push_call = mock_subprocess.call_args_list[4]
     assert push_call[0][0] == ["git", "push", "--set-upstream", "origin", "HEAD"]
     assert push_call[1]["cwd"] == "/path/to/repo"
 
-    # Verify gh pr create was called fourth
-    pr_call = mock_subprocess.call_args_list[3]
+    # Verify gh pr create was called sixth
+    pr_call = mock_subprocess.call_args_list[5]
     assert pr_call[0][0][0:3] == ["gh", "pr", "create"]
     assert pr_call[1]["cwd"] == "/path/to/repo"
 
@@ -381,13 +393,22 @@ def test_create_pr_step_gh_command_failure(mock_subprocess, mock_emit, mock_whic
     # Mock shutil.which to indicate gh CLI is available
     mock_which.return_value = "/usr/bin/gh"
 
-    # Step calls: rev-parse, pr list (empty), push (success), pr create (failure)
+    # Step calls: rev-parse, pr list (empty), delta check (2), push (success), pr create (failure)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_pr_list = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count = Mock(returncode=0, stdout="1\n", stderr="")
     mock_push_result = Mock(returncode=0, stdout="", stderr="")
     mock_pr_result = Mock(returncode=1, stderr="error: could not create pull request")
 
-    mock_subprocess.side_effect = [mock_rev_parse, mock_pr_list, mock_push_result, mock_pr_result]
+    mock_subprocess.side_effect = [
+        mock_rev_parse,
+        mock_pr_list,
+        mock_base_check,
+        mock_ahead_count,
+        mock_push_result,
+        mock_pr_result,
+    ]
 
     # Mock emit_comment_from_payload success
     mock_emit.return_value = ("success", "Comment inserted")
@@ -504,13 +525,22 @@ def test_create_pr_step_push_failure_continues_to_pr(
     # Mock shutil.which to indicate gh CLI is available
     mock_which.return_value = "/usr/bin/gh"
 
-    # Step calls: rev-parse, pr list (empty), push (failure → best-effort), pr create (success)
+    # Step calls: rev-parse, pr list (empty), delta check (2), push (failure → best-effort), pr create (success)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_pr_list = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count = Mock(returncode=0, stdout="1\n", stderr="")
     mock_push_result = Mock(returncode=1, stdout="", stderr="error: failed to push some refs")
     mock_pr_result = Mock(returncode=0, stdout="https://github.com/owner/repo/pull/123\n")
 
-    mock_subprocess.side_effect = [mock_rev_parse, mock_pr_list, mock_push_result, mock_pr_result]
+    mock_subprocess.side_effect = [
+        mock_rev_parse,
+        mock_pr_list,
+        mock_base_check,
+        mock_ahead_count,
+        mock_push_result,
+        mock_pr_result,
+    ]
 
     # Mock emit_comment_from_payload success
     mock_emit.return_value = ("success", "Comment inserted")
@@ -527,7 +557,7 @@ def test_create_pr_step_push_failure_continues_to_pr(
 
     # PR should succeed even if push failed (branch may already exist on remote)
     assert result.success is True
-    assert mock_subprocess.call_count == 4
+    assert mock_subprocess.call_count == 6
     mock_emit.assert_called_once()
     assert mock_emit.call_args[0][0].raw["output"] == "pull-request-created"
 
@@ -549,14 +579,18 @@ def test_create_pr_step_push_timeout_continues_to_pr(
     # Mock shutil.which to indicate gh CLI is available
     mock_which.return_value = "/usr/bin/gh"
 
-    # Step calls: rev-parse, pr list (empty), push (timeout → caught, best-effort), pr create
+    # Step calls: rev-parse, pr list (empty), delta check (2), push (timeout → caught, best-effort), pr create
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_pr_list = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count = Mock(returncode=0, stdout="1\n", stderr="")
     mock_pr_result = Mock(returncode=0, stdout="https://github.com/owner/repo/pull/123\n")
 
     mock_subprocess.side_effect = [
         mock_rev_parse,
         mock_pr_list,
+        mock_base_check,
+        mock_ahead_count,
         subprocess.TimeoutExpired(cmd="git", timeout=60),
         mock_pr_result,
     ]
@@ -576,7 +610,7 @@ def test_create_pr_step_push_timeout_continues_to_pr(
 
     # PR should succeed even if push timed out
     assert result.success is True
-    assert mock_subprocess.call_count == 4
+    assert mock_subprocess.call_count == 6
     mock_emit.assert_called_once()
     assert mock_emit.call_args[0][0].raw["output"] == "pull-request-created"
 
@@ -593,9 +627,11 @@ def test_create_pr_step_multi_repo_success(mock_emit, mock_subprocess, mock_whic
     mock_which.return_value = "/usr/bin/gh"
     mock_emit.return_value = ("success", "Comment inserted")
 
-    # Two repos: each needs rev-parse, pr list (empty), push, pr create — 4 calls each = 8 total
+    # Two repos: each needs rev-parse, pr list (empty), delta check (2), push, pr create — 6 calls each = 12 total
     mock_rev_parse_a = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_pr_list_a = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check_a = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count_a = Mock(returncode=0, stdout="1\n", stderr="")
     mock_push_a = Mock(returncode=0, stdout="", stderr="")
     mock_pr_create_a = Mock(
         returncode=0, stdout="https://github.com/owner/repo-a/pull/1\n", stderr=""
@@ -603,6 +639,8 @@ def test_create_pr_step_multi_repo_success(mock_emit, mock_subprocess, mock_whic
 
     mock_rev_parse_b = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_pr_list_b = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check_b = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count_b = Mock(returncode=0, stdout="1\n", stderr="")
     mock_push_b = Mock(returncode=0, stdout="", stderr="")
     mock_pr_create_b = Mock(
         returncode=0, stdout="https://github.com/owner/repo-b/pull/2\n", stderr=""
@@ -611,10 +649,14 @@ def test_create_pr_step_multi_repo_success(mock_emit, mock_subprocess, mock_whic
     mock_subprocess.side_effect = [
         mock_rev_parse_a,
         mock_pr_list_a,
+        mock_base_check_a,
+        mock_ahead_count_a,
         mock_push_a,
         mock_pr_create_a,
         mock_rev_parse_b,
         mock_pr_list_b,
+        mock_base_check_b,
+        mock_ahead_count_b,
         mock_push_b,
         mock_pr_create_b,
     ]
@@ -630,23 +672,23 @@ def test_create_pr_step_multi_repo_success(mock_emit, mock_subprocess, mock_whic
     result = step.run(context)
 
     assert result.success is True
-    # Subprocess called 4 times per repo = 8 total
-    assert mock_subprocess.call_count == 8
+    # Subprocess called 6 times per repo = 12 total
+    assert mock_subprocess.call_count == 12
 
     # Verify each repo's push and pr-create used the correct cwd
-    push_call_a = mock_subprocess.call_args_list[2]
+    push_call_a = mock_subprocess.call_args_list[4]
     assert push_call_a[1]["cwd"] == "/repo/a"
     assert push_call_a[0][0] == ["git", "push", "--set-upstream", "origin", "HEAD"]
 
-    pr_create_call_a = mock_subprocess.call_args_list[3]
+    pr_create_call_a = mock_subprocess.call_args_list[5]
     assert pr_create_call_a[1]["cwd"] == "/repo/a"
     assert pr_create_call_a[0][0][0:3] == ["gh", "pr", "create"]
 
-    push_call_b = mock_subprocess.call_args_list[6]
+    push_call_b = mock_subprocess.call_args_list[10]
     assert push_call_b[1]["cwd"] == "/repo/b"
     assert push_call_b[0][0] == ["git", "push", "--set-upstream", "origin", "HEAD"]
 
-    pr_create_call_b = mock_subprocess.call_args_list[7]
+    pr_create_call_b = mock_subprocess.call_args_list[11]
     assert pr_create_call_b[1]["cwd"] == "/repo/b"
     assert pr_create_call_b[0][0][0:3] == ["gh", "pr", "create"]
 
@@ -674,25 +716,33 @@ def test_create_pr_step_multi_repo_failure(mock_emit, mock_subprocess, mock_whic
     mock_which.return_value = "/usr/bin/gh"
     mock_emit.return_value = ("success", "Comment inserted")
 
-    # Two repos: each needs rev-parse, pr list (empty), push, pr create (fail)
-    # — 4 calls each = 8 total
+    # Two repos: each needs rev-parse, pr list (empty), delta check (2), push, pr create (fail)
+    # — 6 calls each = 12 total
     mock_rev_parse_a = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_pr_list_a = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check_a = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count_a = Mock(returncode=0, stdout="1\n", stderr="")
     mock_push_a = Mock(returncode=0, stdout="", stderr="")
     mock_pr_fail_a = Mock(returncode=1, stdout="", stderr="error: could not create PR for repo-a")
 
     mock_rev_parse_b = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_pr_list_b = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check_b = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count_b = Mock(returncode=0, stdout="1\n", stderr="")
     mock_push_b = Mock(returncode=0, stdout="", stderr="")
     mock_pr_fail_b = Mock(returncode=1, stdout="", stderr="error: could not create PR for repo-b")
 
     mock_subprocess.side_effect = [
         mock_rev_parse_a,
         mock_pr_list_a,
+        mock_base_check_a,
+        mock_ahead_count_a,
         mock_push_a,
         mock_pr_fail_a,
         mock_rev_parse_b,
         mock_pr_list_b,
+        mock_base_check_b,
+        mock_ahead_count_b,
         mock_push_b,
         mock_pr_fail_b,
     ]
@@ -709,14 +759,14 @@ def test_create_pr_step_multi_repo_failure(mock_emit, mock_subprocess, mock_whic
 
     # Step is best-effort: returns success even when all repos fail
     assert result.success is True
-    # Subprocess called 4 times per repo = 8 total (loop continues on per-repo failure)
-    assert mock_subprocess.call_count == 8
+    # Subprocess called 6 times per repo = 12 total (loop continues on per-repo failure)
+    assert mock_subprocess.call_count == 12
 
     # Verify the step attempted both repos (push cwd per repo)
-    push_call_a = mock_subprocess.call_args_list[2]
+    push_call_a = mock_subprocess.call_args_list[4]
     assert push_call_a[1]["cwd"] == "/repo/a"
 
-    push_call_b = mock_subprocess.call_args_list[6]
+    push_call_b = mock_subprocess.call_args_list[10]
     assert push_call_b[1]["cwd"] == "/repo/b"
 
     # emit_comment_from_payload called once per failing repo = 2 total
@@ -766,15 +816,24 @@ def test_create_gitlab_mr_step_success(mock_emit, mock_subprocess) -> None:
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
-    # Step calls: git rev-parse, glab mr list (empty), git push, glab mr create
+    # Step calls: git rev-parse, glab mr list (empty), delta check (2), git push, glab mr create
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_mr_list = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count = Mock(returncode=0, stdout="1\n", stderr="")
     mock_push_result = Mock(returncode=0, stdout="", stderr="")
     mock_mr_result = Mock(
         returncode=0, stdout="https://gitlab.com/owner/repo/-/merge_requests/123\n"
     )
 
-    mock_subprocess.side_effect = [mock_rev_parse, mock_mr_list, mock_push_result, mock_mr_result]
+    mock_subprocess.side_effect = [
+        mock_rev_parse,
+        mock_mr_list,
+        mock_base_check,
+        mock_ahead_count,
+        mock_push_result,
+        mock_mr_result,
+    ]
 
     # Mock emit_comment_from_payload success
     mock_emit.return_value = ("success", "Comment inserted")
@@ -790,16 +849,16 @@ def test_create_gitlab_mr_step_success(mock_emit, mock_subprocess) -> None:
     result = step.run(context)
 
     assert result.success is True
-    assert mock_subprocess.call_count == 4
+    assert mock_subprocess.call_count == 6
     mock_emit.assert_called_once()
 
-    # Verify git push was called third
-    push_call = mock_subprocess.call_args_list[2]
+    # Verify git push was called fifth
+    push_call = mock_subprocess.call_args_list[4]
     assert push_call[0][0] == ["git", "push", "--set-upstream", "origin", "HEAD"]
     assert push_call[1]["cwd"] == "/path/to/repo"
 
-    # Verify glab mr create was called fourth
-    mr_call = mock_subprocess.call_args_list[3]
+    # Verify glab mr create was called sixth
+    mr_call = mock_subprocess.call_args_list[5]
     assert mr_call[0][0][0:3] == ["glab", "mr", "create"]
     assert mr_call[1]["cwd"] == "/path/to/repo"
 
@@ -917,13 +976,22 @@ def test_create_gitlab_mr_step_glab_command_failure(
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
 
-    # Step calls: rev-parse, mr list (empty), push (success), glab mr create (failure)
+    # Step calls: rev-parse, mr list (empty), delta check (2), push (success), glab mr create (failure)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_mr_list = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count = Mock(returncode=0, stdout="1\n", stderr="")
     mock_push_result = Mock(returncode=0, stdout="", stderr="")
     mock_mr_result = Mock(returncode=1, stderr="error: could not create merge request")
 
-    mock_subprocess.side_effect = [mock_rev_parse, mock_mr_list, mock_push_result, mock_mr_result]
+    mock_subprocess.side_effect = [
+        mock_rev_parse,
+        mock_mr_list,
+        mock_base_check,
+        mock_ahead_count,
+        mock_push_result,
+        mock_mr_result,
+    ]
 
     # Mock emit_comment_from_payload success
     mock_emit.return_value = ("success", "Comment inserted")
@@ -959,14 +1027,18 @@ def test_create_gitlab_mr_step_timeout(mock_subprocess, mock_get_logger, mock_em
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
 
-    # Step calls: rev-parse, mr list (empty), push, glab mr create (timeout caught per-repo)
+    # Step calls: rev-parse, mr list (empty), delta check (2), push, glab mr create (timeout caught per-repo)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_mr_list = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count = Mock(returncode=0, stdout="1\n", stderr="")
     mock_push_result = Mock(returncode=0, stdout="", stderr="")
 
     mock_subprocess.side_effect = [
         mock_rev_parse,
         mock_mr_list,
+        mock_base_check,
+        mock_ahead_count,
         mock_push_result,
         subprocess.TimeoutExpired(cmd="glab", timeout=120),
     ]
@@ -1044,15 +1116,24 @@ def test_create_gitlab_mr_step_push_failure_continues_to_mr(mock_subprocess, moc
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
-    # Step calls: rev-parse, mr list (empty), push (failure → best-effort), glab mr create (success)
+    # Step calls: rev-parse, mr list (empty), delta check (2), push (failure → best-effort), glab mr create (success)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_mr_list = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count = Mock(returncode=0, stdout="1\n", stderr="")
     mock_push_result = Mock(returncode=1, stdout="", stderr="error: failed to push some refs")
     mock_mr_result = Mock(
         returncode=0, stdout="https://gitlab.com/owner/repo/-/merge_requests/123\n"
     )
 
-    mock_subprocess.side_effect = [mock_rev_parse, mock_mr_list, mock_push_result, mock_mr_result]
+    mock_subprocess.side_effect = [
+        mock_rev_parse,
+        mock_mr_list,
+        mock_base_check,
+        mock_ahead_count,
+        mock_push_result,
+        mock_mr_result,
+    ]
 
     # Mock emit_comment_from_payload success
     mock_emit.return_value = ("success", "Comment inserted")
@@ -1069,7 +1150,7 @@ def test_create_gitlab_mr_step_push_failure_continues_to_mr(mock_subprocess, moc
 
     # MR should succeed even if push failed (branch may already exist on remote)
     assert result.success is True
-    assert mock_subprocess.call_count == 4
+    assert mock_subprocess.call_count == 6
     mock_emit.assert_called_once()
     assert mock_emit.call_args[0][0].raw["output"] == "merge-request-created"
 
@@ -1083,9 +1164,11 @@ def test_create_gitlab_mr_step_push_timeout_continues_to_mr(mock_subprocess, moc
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
-    # Step calls: rev-parse, mr list (empty), push (timeout → best-effort), glab mr create (success)
+    # Step calls: rev-parse, mr list (empty), delta check (2), push (timeout → best-effort), glab mr create (success)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_mr_list = Mock(returncode=0, stdout="[]", stderr="")
+    mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
+    mock_ahead_count = Mock(returncode=0, stdout="1\n", stderr="")
     mock_mr_result = Mock(
         returncode=0, stdout="https://gitlab.com/owner/repo/-/merge_requests/123\n"
     )
@@ -1093,6 +1176,8 @@ def test_create_gitlab_mr_step_push_timeout_continues_to_mr(mock_subprocess, moc
     mock_subprocess.side_effect = [
         mock_rev_parse,
         mock_mr_list,
+        mock_base_check,
+        mock_ahead_count,
         subprocess.TimeoutExpired(cmd="git", timeout=60),
         mock_mr_result,
     ]
@@ -1112,7 +1197,7 @@ def test_create_gitlab_mr_step_push_timeout_continues_to_mr(mock_subprocess, moc
 
     # MR should succeed even if push timed out
     assert result.success is True
-    assert mock_subprocess.call_count == 4
+    assert mock_subprocess.call_count == 6
     mock_emit.assert_called_once()
     assert mock_emit.call_args[0][0].raw["output"] == "merge-request-created"
 
@@ -1178,15 +1263,17 @@ def test_prepare_pr_step_store_pr_details_missing_fields() -> None:
     assert context.data["pr_details"]["commits"] == []
 
 
+@patch("rouge.core.workflow.steps.compose_request_step.get_affected_repos")
 @patch("rouge.core.workflow.steps.compose_request_step.emit_comment_from_payload")
 @patch("rouge.core.workflow.steps.compose_request_step.execute_template")
 @patch("rouge.core.workflow.steps.compose_request_step.update_status")
 def test_prepare_pr_step_emits_raw_llm_response(
-    mock_update_status, mock_execute, mock_emit
+    mock_update_status, mock_execute, mock_emit, mock_get_affected
 ) -> None:
     """Test ComposeRequestStep emits raw LLM response for debugging."""
 
     from rouge.core.workflow.steps.compose_request_step import ComposeRequestStep
+    from rouge.core.workflow.types import ImplementData
 
     # Mock emit_comment_from_payload success
     mock_emit.return_value = ("success", "Comment inserted")
@@ -1203,6 +1290,7 @@ def test_prepare_pr_step_emits_raw_llm_response(
     mock_execute.return_value = mock_response
 
     context = _make_context()
+    mock_get_affected.return_value = (context.repo_paths, ImplementData(output="done"))
     step = ComposeRequestStep()
     result = step.run(context)
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -525,7 +525,8 @@ def test_create_pr_step_push_failure_continues_to_pr(
     # Mock shutil.which to indicate gh CLI is available
     mock_which.return_value = "/usr/bin/gh"
 
-    # Step calls: rev-parse, pr list (empty), delta check (2), push (failure → best-effort), pr create (success)
+    # Step calls: rev-parse, pr list (empty), delta check (2),
+    # push (failure → best-effort), pr create (success)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_pr_list = Mock(returncode=0, stdout="[]", stderr="")
     mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
@@ -579,7 +580,8 @@ def test_create_pr_step_push_timeout_continues_to_pr(
     # Mock shutil.which to indicate gh CLI is available
     mock_which.return_value = "/usr/bin/gh"
 
-    # Step calls: rev-parse, pr list (empty), delta check (2), push (timeout → caught, best-effort), pr create
+    # Step calls: rev-parse, pr list (empty), delta check (2),
+    # push (timeout → caught, best-effort), pr create
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_pr_list = Mock(returncode=0, stdout="[]", stderr="")
     mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
@@ -627,7 +629,8 @@ def test_create_pr_step_multi_repo_success(mock_emit, mock_subprocess, mock_whic
     mock_which.return_value = "/usr/bin/gh"
     mock_emit.return_value = ("success", "Comment inserted")
 
-    # Two repos: each needs rev-parse, pr list (empty), delta check (2), push, pr create — 6 calls each = 12 total
+    # Two repos: each needs rev-parse, pr list (empty), delta check (2),
+    # push, pr create — 6 calls each = 12 total
     mock_rev_parse_a = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_pr_list_a = Mock(returncode=0, stdout="[]", stderr="")
     mock_base_check_a = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
@@ -976,7 +979,8 @@ def test_create_gitlab_mr_step_glab_command_failure(
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
 
-    # Step calls: rev-parse, mr list (empty), delta check (2), push (success), glab mr create (failure)
+    # Step calls: rev-parse, mr list (empty), delta check (2),
+    # push (success), glab mr create (failure)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_mr_list = Mock(returncode=0, stdout="[]", stderr="")
     mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
@@ -1027,7 +1031,8 @@ def test_create_gitlab_mr_step_timeout(mock_subprocess, mock_get_logger, mock_em
     mock_logger = MagicMock()
     mock_get_logger.return_value = mock_logger
 
-    # Step calls: rev-parse, mr list (empty), delta check (2), push, glab mr create (timeout caught per-repo)
+    # Step calls: rev-parse, mr list (empty), delta check (2),
+    # push, glab mr create (timeout caught per-repo)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_mr_list = Mock(returncode=0, stdout="[]", stderr="")
     mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
@@ -1116,7 +1121,8 @@ def test_create_gitlab_mr_step_push_failure_continues_to_mr(mock_subprocess, moc
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
-    # Step calls: rev-parse, mr list (empty), delta check (2), push (failure → best-effort), glab mr create (success)
+    # Step calls: rev-parse, mr list (empty), delta check (2),
+    # push (failure → best-effort), glab mr create (success)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_mr_list = Mock(returncode=0, stdout="[]", stderr="")
     mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")
@@ -1164,7 +1170,8 @@ def test_create_gitlab_mr_step_push_timeout_continues_to_mr(mock_subprocess, moc
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
-    # Step calls: rev-parse, mr list (empty), delta check (2), push (timeout → best-effort), glab mr create (success)
+    # Step calls: rev-parse, mr list (empty), delta check (2),
+    # push (timeout → best-effort), glab mr create (success)
     mock_rev_parse = Mock(returncode=0, stdout="my-branch\n", stderr="")
     mock_mr_list = Mock(returncode=0, stdout="[]", stderr="")
     mock_base_check = Mock(returncode=0, stdout="origin/HEAD\n", stderr="")


### PR DESCRIPTION
## Description

Introduces affected-repo tracking through the workflow pipeline so that code-quality checks, PR composition, and PR/MR creation are scoped to only the repositories that were changed by the implementation step. This eliminates spurious empty PRs and unnecessary LLM calls for repos the agent didn't touch.

Depends on: no external dependencies added.

Resolves: https://github.com/bponghneng/rouge/issues/176

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Added `RepoChangeEntry` model and extended `ImplementData` with `affected_repos`, `repos`, `files_modified`, `git_diff_stat`, and `summary` fields in `types.py`
- Added `get_affected_repos` shared helper (`repo_filter.py`) that reads the implement artifact and returns filtered repo paths in `context.repo_paths` order
- `ImplementStep` now detects affected repos by mapping `files_modified` to repo paths (with git-diff fallback) and writes them into the artifact
- `CodeQualityStep` passes affected repos as `$ARGUMENTS` to the agent and writes a skip artifact when no repos are affected; the prompt template honours `$ARGUMENTS` scope
- `ComposeRequestStep` passes affected repos as template args and writes a skip artifact when nothing changed
- `GhPullRequestStep` and `GlabPullRequestStep` use `get_affected_repos` for repo filtering and skip PR/MR creation for branches with no commits ahead of base
- Registry: `code-quality` and `compose-request` implement deps promoted from ordering-only to required; `gh-pull-request` and `glab-pull-request` gain an optional `implement` dependency
- Tests updated throughout: new `TestCodeQualityAffectedRepos` and `TestComposeRequestAffectedRepos` suites, updated subprocess call-count expectations for the new delta-check calls, and adjusted dependency-contract assertions

## How to Test

- [ ] Run `uv run pytest tests/ -v` — all tests should pass
- [ ] Run a full ADW workflow against a multi-repo issue where only one repo changes; verify code-quality and PR steps skip the unmodified repo
- [ ] Run a full ADW workflow where no repos are modified; verify code-quality and compose-request write skip artifacts and the pipeline completes successfully
- [ ] Verify `uv run ruff check src/` and `uv run mypy` report no new errors