### PR TITLE
feat(workflow): post patch review-context attachment in compose-commits step

### DIFF
--- a/src/rouge/core/workflow/step_registry.py
+++ b/src/rouge/core/workflow/step_registry.py
@@ -502,6 +502,7 @@ def _register_default_steps(registry: StepRegistry) -> None:
         ComposeCommitsStep,
         slug="compose-commits",
         dependencies=["fetch-patch", "plan"],
+        dependency_kinds={"fetch-patch": "optional", "plan": "optional"},
         outputs=["compose-commits"],
         is_critical=False,
         description="Push patch commits to existing PR/MR (detects PR via gh/glab CLI)",

--- a/src/rouge/core/workflow/step_registry.py
+++ b/src/rouge/core/workflow/step_registry.py
@@ -501,7 +501,7 @@ def _register_default_steps(registry: StepRegistry) -> None:
     registry.register(
         ComposeCommitsStep,
         slug="compose-commits",
-        dependencies=[],
+        dependencies=["fetch-patch", "plan"],
         outputs=["compose-commits"],
         is_critical=False,
         description="Push patch commits to existing PR/MR (detects PR via gh/glab CLI)",

--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -320,7 +320,7 @@ def post_glab_attachment_note(
                 if note.get("body", "").startswith(_REVIEW_CONTEXT_MARKER):
                     existing_note_id = int(note["id"])
                     break
-        except (ValueError, KeyError):
+        except (ValueError, KeyError, TypeError, AttributeError):
             logger.debug("Failed to parse GitLab notes response for MR !%d", mr_number)
 
     if existing_note_id:

--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -168,6 +168,40 @@ def load_and_render_attachment(context: "WorkflowContext") -> str | None:
     )
 
 
+def load_and_render_patch_attachment(context: "WorkflowContext") -> str | None:
+    """Load fetch-patch and plan artifacts and render the PR/MR attachment markdown.
+
+    This mirrors :func:`load_and_render_attachment` but reads from the
+    ``fetch-patch`` artifact instead of ``fetch-issue``.  Returns ``None``
+    when neither artifact is present.
+
+    Args:
+        context: The workflow context providing artifact loading.
+
+    Returns:
+        Rendered Markdown string, or ``None`` if both artifacts are absent.
+    """
+    from rouge.core.workflow.artifacts import FetchPatchArtifact, PlanArtifact
+
+    patch_data = context.load_optional_artifact(
+        "fetch_patch_data",
+        "fetch-patch",
+        FetchPatchArtifact,
+        lambda a: {"description": a.patch.description},
+    )
+    plan_data = context.load_optional_artifact(
+        "plan_data",
+        "plan",
+        PlanArtifact,
+        lambda a: a.plan_data,
+    )
+    return render_attachment_markdown(
+        spec_text=patch_data["description"] if patch_data else None,
+        plan_text=plan_data.plan if plan_data else None,
+        plan_summary=plan_data.summary if plan_data else None,
+    )
+
+
 def _emit_and_log(issue_id: int, adw_id: str, text: str, raw: dict[str, Any]) -> None:
     """Helper to emit comment and log based on status.
 

--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -320,7 +320,7 @@ def post_glab_attachment_note(
                     existing_note_id = note["id"]
                     break
         except (ValueError, KeyError):
-            pass
+            logger.debug("Failed to parse GitLab notes response for MR !%d", mr_number)
 
     if existing_note_id:
         update_cmd = [

--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -59,6 +59,8 @@ def _sanitize_for_logging(text: Optional[str], max_length: int = MAX_LOG_LENGTH)
 _MAX_BODY_CHARS = 60_000
 _TRUNCATION_NOTICE = "\n\n… *(content truncated to fit platform limits)*"
 
+_REVIEW_CONTEXT_MARKER = "<!-- rouge-review-context -->"
+
 
 def render_attachment_markdown(
     spec_text: str | None,
@@ -222,8 +224,7 @@ def post_gh_attachment_comment(
         env: Environment dict with the appropriate token set.
     """
     logger = get_logger(__name__)
-    marker = "<!-- rouge-review-context -->"
-    tagged_body = f"{marker}\n{body}"
+    tagged_body = f"{_REVIEW_CONTEXT_MARKER}\n{body}"
 
     list_cmd = [
         "gh",
@@ -233,7 +234,7 @@ def post_gh_attachment_comment(
         "--json",
         "comments",
         "--jq",
-        '.comments[] | select(.body | startswith("<!-- rouge-review-context -->")) | .databaseId',
+        f'.comments[] | select(.body | startswith("{_REVIEW_CONTEXT_MARKER}")) | .databaseId',
     ]
     result = subprocess.run(
         list_cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
@@ -299,9 +300,9 @@ def post_glab_attachment_note(
         env: Environment dict with the appropriate token set.
     """
     logger = get_logger(__name__)
-    marker = "<!-- rouge-review-context -->"
-    tagged_body = f"{marker}\n{body}"
+    tagged_body = f"{_REVIEW_CONTEXT_MARKER}\n{body}"
 
+    # NOTE: per_page=100 without pagination; duplicates possible on MRs with 100+ notes.
     list_cmd = [
         "glab",
         "api",
@@ -316,8 +317,8 @@ def post_glab_attachment_note(
         try:
             notes = json.loads(result.stdout)
             for note in notes:
-                if note.get("body", "").startswith(marker):
-                    existing_note_id = note["id"]
+                if note.get("body", "").startswith(_REVIEW_CONTEXT_MARKER):
+                    existing_note_id = int(note["id"])
                     break
         except (ValueError, KeyError):
             logger.debug("Failed to parse GitLab notes response for MR !%d", mr_number)

--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -1,6 +1,8 @@
 """Shared utility helpers for workflow step implementations."""
 
+import json
 import re
+import subprocess
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
@@ -200,6 +202,160 @@ def load_and_render_patch_attachment(context: "WorkflowContext") -> str | None:
         plan_text=plan_data.plan if plan_data else None,
         plan_summary=plan_data.summary if plan_data else None,
     )
+
+
+def post_gh_attachment_comment(
+    repo_path: str,
+    pr_number: int,
+    body: str,
+    env: dict[str, str],
+) -> None:
+    """Post or update the Rouge review-context comment on a GitHub PR.
+
+    Shared by GhPullRequestStep and ComposeCommitsStep so neither step
+    module imports from a sibling step module.
+
+    Args:
+        repo_path: Path to the repository root.
+        pr_number: The pull request number.
+        body: Markdown body for the comment.
+        env: Environment dict with the appropriate token set.
+    """
+    logger = get_logger(__name__)
+    marker = "<!-- rouge-review-context -->"
+    tagged_body = f"{marker}\n{body}"
+
+    list_cmd = [
+        "gh",
+        "pr",
+        "view",
+        str(pr_number),
+        "--json",
+        "comments",
+        "--jq",
+        '.comments[] | select(.body | startswith("<!-- rouge-review-context -->")) | .databaseId',
+    ]
+    result = subprocess.run(
+        list_cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
+    )
+
+    existing_comment_id = (
+        result.stdout.strip().split("\n")[0]
+        if result.returncode == 0 and result.stdout.strip()
+        else None
+    )
+
+    if existing_comment_id and existing_comment_id.isdigit():
+        update_cmd = [
+            "gh",
+            "api",
+            "--method",
+            "PATCH",
+            f"/repos/{{owner}}/{{repo}}/issues/comments/{existing_comment_id}",
+            "-f",
+            f"body={tagged_body}",
+        ]
+        update_result = subprocess.run(
+            update_cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
+        )
+        if update_result.returncode != 0:
+            logger.warning(
+                "Failed to update review-context comment on PR #%d: %s",
+                pr_number,
+                update_result.stderr,
+            )
+        else:
+            logger.info("Updated review-context comment on PR #%d", pr_number)
+    else:
+        cmd = ["gh", "pr", "comment", str(pr_number), "--body", tagged_body]
+        create_result = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
+        )
+        if create_result.returncode != 0:
+            logger.warning(
+                "Failed to post review-context comment on PR #%d: %s",
+                pr_number,
+                create_result.stderr,
+            )
+        else:
+            logger.info("Posted review-context comment on PR #%d", pr_number)
+
+
+def post_glab_attachment_note(
+    repo_path: str,
+    mr_number: int,
+    body: str,
+    env: dict[str, str],
+) -> None:
+    """Post or update the Rouge review-context note on a GitLab MR.
+
+    Shared by GlabPullRequestStep and ComposeCommitsStep so neither step
+    module imports from a sibling step module.
+
+    Args:
+        repo_path: Path to the repository root.
+        mr_number: The merge request IID.
+        body: Markdown body for the note.
+        env: Environment dict with the appropriate token set.
+    """
+    logger = get_logger(__name__)
+    marker = "<!-- rouge-review-context -->"
+    tagged_body = f"{marker}\n{body}"
+
+    list_cmd = [
+        "glab",
+        "api",
+        f"projects/:id/merge_requests/{mr_number}/notes?per_page=100",
+    ]
+    result = subprocess.run(
+        list_cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
+    )
+
+    existing_note_id = None
+    if result.returncode == 0 and result.stdout.strip():
+        try:
+            notes = json.loads(result.stdout)
+            for note in notes:
+                if note.get("body", "").startswith(marker):
+                    existing_note_id = note["id"]
+                    break
+        except (ValueError, KeyError):
+            pass
+
+    if existing_note_id:
+        update_cmd = [
+            "glab",
+            "api",
+            "--method",
+            "PUT",
+            f"projects/:id/merge_requests/{mr_number}/notes/{existing_note_id}",
+            "-f",
+            f"body={tagged_body}",
+        ]
+        update_result = subprocess.run(
+            update_cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
+        )
+        if update_result.returncode != 0:
+            logger.warning(
+                "Failed to update review-context note on MR !%d: %s",
+                mr_number,
+                update_result.stderr,
+            )
+        else:
+            logger.info("Updated review-context note on MR !%d", mr_number)
+    else:
+        cmd = ["glab", "mr", "note", str(mr_number), "--message", tagged_body]
+        create_result = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
+        )
+        if create_result.returncode != 0:
+            logger.warning(
+                "Failed to post review-context note on MR !%d: %s",
+                mr_number,
+                create_result.stderr,
+            )
+        else:
+            logger.info("Posted review-context note on MR !%d", mr_number)
 
 
 def _emit_and_log(issue_id: int, adw_id: str, text: str, raw: dict[str, Any]) -> None:

--- a/src/rouge/core/workflow/steps/compose_commits_step.py
+++ b/src/rouge/core/workflow/steps/compose_commits_step.py
@@ -261,23 +261,14 @@ class ComposeCommitsStep(WorkflowStep):
             )
             return StepResult.fail(error_msg)
 
-    def run(self, context: WorkflowContext) -> StepResult:
-        """Push new commits to existing PR/MRs across all repos.
+    def _compose_commits(self, context: WorkflowContext) -> Optional[StepResult]:
+        """Compose conventional commits from unstaged changes via the LLM agent.
 
-        Detects the PR/MR platform by running the CLI indicated by
-        DEV_SEC_OPS_PLATFORM rather than loading artifacts from a parent workflow.
-        Iterates over all repos in ``context.repo_paths`` and pushes each one
-        independently.
-
-        Args:
-            context: Workflow context
-
-        Returns:
-            StepResult with success status and optional error message
+        Returns ``None`` on success (caller should continue) or a
+        :class:`StepResult` on failure (caller should return it immediately).
         """
         logger = get_logger(context.adw_id)
 
-        # Compose conventional commits from unstaged changes
         try:
             request = ClaudeAgentTemplateRequest(
                 agent_name=AGENT_COMMIT_COMPOSER,
@@ -365,14 +356,19 @@ class ComposeCommitsStep(WorkflowStep):
             )
             return StepResult.fail(error_msg)
 
-        # Render review-context attachment once (best-effort, never blocks workflow)
-        attachment_md: str | None = None
-        try:
-            attachment_md = load_and_render_patch_attachment(context)
-        except Exception:
-            logger.error("Failed to render patch review-context attachment", exc_info=True)
+        return None
 
-        # Multi-repo PR detection and push loop
+    def _push_all_repos(
+        self,
+        context: WorkflowContext,
+        attachment_md: str | None,
+    ) -> StepResult:
+        """Detect PR/MR platform for each repo and push commits.
+
+        Posts the review-context attachment after each successful push when
+        *attachment_md* is not ``None``.
+        """
+        logger = get_logger(context.adw_id)
         issue_id = context.require_issue_id
         succeeded: List[str] = []
         errors: List[str] = []
@@ -474,3 +470,33 @@ class ComposeCommitsStep(WorkflowStep):
             {"output": "pr-update-failed", "error": error_msg},
         )
         return StepResult.fail(error_msg)
+
+    def run(self, context: WorkflowContext) -> StepResult:
+        """Push new commits to existing PR/MRs across all repos.
+
+        Detects the PR/MR platform by running the CLI indicated by
+        DEV_SEC_OPS_PLATFORM rather than loading artifacts from a parent workflow.
+        Iterates over all repos in ``context.repo_paths`` and pushes each one
+        independently.
+
+        Args:
+            context: Workflow context
+
+        Returns:
+            StepResult with success status and optional error message
+        """
+        logger = get_logger(context.adw_id)
+
+        # Compose conventional commits from unstaged changes
+        compose_failure = self._compose_commits(context)
+        if compose_failure is not None:
+            return compose_failure
+
+        # Render review-context attachment once (best-effort, never blocks workflow)
+        attachment_md: str | None = None
+        try:
+            attachment_md = load_and_render_patch_attachment(context)
+        except Exception:
+            logger.error("Failed to render patch review-context attachment", exc_info=True)
+
+        return self._push_all_repos(context, attachment_md)

--- a/src/rouge/core/workflow/steps/compose_commits_step.py
+++ b/src/rouge/core/workflow/steps/compose_commits_step.py
@@ -370,7 +370,7 @@ class ComposeCommitsStep(WorkflowStep):
         try:
             attachment_md = load_and_render_patch_attachment(context)
         except Exception:
-            logger.warning("Failed to render patch review-context attachment", exc_info=True)
+            logger.error("Failed to render patch review-context attachment", exc_info=True)
 
         # Multi-repo PR detection and push loop
         issue_id = context.require_issue_id
@@ -444,7 +444,7 @@ class ComposeCommitsStep(WorkflowStep):
                         else:
                             post_glab_attachment_note(repo_path, pr_number, attachment_md, env)
                     except Exception:
-                        logger.warning(
+                        logger.error(
                             "Failed to post review-context on %s for %s",
                             platform,
                             repo_path,

--- a/src/rouge/core/workflow/steps/compose_commits_step.py
+++ b/src/rouge/core/workflow/steps/compose_commits_step.py
@@ -22,9 +22,9 @@ from rouge.core.workflow.step_utils import (
     _emit_and_log,
     _sanitize_for_logging,
     load_and_render_patch_attachment,
+    post_gh_attachment_comment,
+    post_glab_attachment_note,
 )
-from rouge.core.workflow.steps.gh_pull_request_step import _post_gh_attachment_comment
-from rouge.core.workflow.steps.glab_pull_request_step import _post_glab_attachment_note
 from rouge.core.workflow.types import StepResult
 
 # Required fields for compose-commits output JSON
@@ -116,6 +116,8 @@ class ComposeCommitsStep(WorkflowStep):
                     data = json.loads(result.stdout.strip())
                     url = data.get("url", "")
                     number = data.get("number")
+                    if not (isinstance(number, int) and number > 0):
+                        number = None
                     if url:
                         logger.debug("Detected GitHub PR: %s (#%s)", url, number)
                         return ("github", url, number)
@@ -145,6 +147,8 @@ class ComposeCommitsStep(WorkflowStep):
                     data = json.loads(result.stdout.strip())
                     url = data.get("web_url", "")
                     number = data.get("iid")
+                    if not (isinstance(number, int) and number > 0):
+                        number = None
                     if url:
                         logger.debug("Detected GitLab MR: %s (!%s)", url, number)
                         return ("gitlab", url, number)
@@ -366,7 +370,7 @@ class ComposeCommitsStep(WorkflowStep):
         try:
             attachment_md = load_and_render_patch_attachment(context)
         except Exception:
-            logger.debug("Failed to render patch review-context attachment", exc_info=True)
+            logger.warning("Failed to render patch review-context attachment", exc_info=True)
 
         # Multi-repo PR detection and push loop
         issue_id = context.require_issue_id
@@ -436,14 +440,15 @@ class ComposeCommitsStep(WorkflowStep):
                 if attachment_md and pr_number:
                     try:
                         if platform == "github":
-                            _post_gh_attachment_comment(repo_path, pr_number, attachment_md, env)
+                            post_gh_attachment_comment(repo_path, pr_number, attachment_md, env)
                         else:
-                            _post_glab_attachment_note(repo_path, pr_number, attachment_md, env)
-                    except (subprocess.TimeoutExpired, OSError, subprocess.SubprocessError):
+                            post_glab_attachment_note(repo_path, pr_number, attachment_md, env)
+                    except Exception:
                         logger.warning(
                             "Failed to post review-context on %s for %s",
                             platform,
                             repo_path,
+                            exc_info=True,
                         )
             else:
                 errors.append(push_result.error or f"Push failed for {repo_path}")

--- a/src/rouge/core/workflow/steps/compose_commits_step.py
+++ b/src/rouge/core/workflow/steps/compose_commits_step.py
@@ -18,7 +18,13 @@ from rouge.core.utils import get_logger
 from rouge.core.workflow.artifacts import ComposeCommitsArtifact
 from rouge.core.workflow.shared import AGENT_COMMIT_COMPOSER
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
-from rouge.core.workflow.step_utils import _emit_and_log, _sanitize_for_logging
+from rouge.core.workflow.step_utils import (
+    _emit_and_log,
+    _sanitize_for_logging,
+    load_and_render_patch_attachment,
+)
+from rouge.core.workflow.steps.gh_pull_request_step import _post_gh_attachment_comment
+from rouge.core.workflow.steps.glab_pull_request_step import _post_glab_attachment_note
 from rouge.core.workflow.types import StepResult
 
 # Required fields for compose-commits output JSON
@@ -66,20 +72,22 @@ class ComposeCommitsStep(WorkflowStep):
 
     def _detect_pr_platform(
         self, repo_path: str, adw_id: str
-    ) -> Tuple[Optional[str], Optional[str]]:
-        """Detect the existing PR/MR platform and URL using git CLI tools.
+    ) -> Tuple[Optional[str], Optional[str], Optional[int]]:
+        """Detect the existing PR/MR platform, URL, and number using git CLI tools.
 
         Uses DEV_SEC_OPS_PLATFORM to select either GitHub or GitLab and
         invokes the corresponding CLI. If the env var is missing or invalid,
-        returns (None, None).
+        returns (None, None, None).
 
         Args:
             repo_path: Path to the repository root
             adw_id: Workflow ID for logger retrieval
 
         Returns:
-            Tuple of (platform, url) where platform is "github" or "gitlab",
-            or (None, None) if no PR/MR is detected or no CLI tool is available.
+            Tuple of (platform, url, number) where platform is "github" or
+            "gitlab" and number is the PR/MR number (int), or
+            (None, None, None) if no PR/MR is detected or no CLI tool is
+            available.
         """
         logger = get_logger(adw_id)
         platform = os.environ.get("DEV_SEC_OPS_PLATFORM", "").lower()
@@ -87,7 +95,7 @@ class ComposeCommitsStep(WorkflowStep):
             logger.warning(
                 "DEV_SEC_OPS_PLATFORM is not set to a supported platform (github/gitlab)"
             )
-            return (None, None)
+            return (None, None, None)
 
         if platform == "github":
             github_pat = os.environ.get("GITHUB_PAT")
@@ -97,7 +105,7 @@ class ComposeCommitsStep(WorkflowStep):
 
             try:
                 result = subprocess.run(
-                    ["gh", "pr", "view", "--json", "url"],
+                    ["gh", "pr", "view", "--json", "url,number"],
                     capture_output=True,
                     text=True,
                     env=env,
@@ -107,9 +115,10 @@ class ComposeCommitsStep(WorkflowStep):
                 if result.returncode == 0:
                     data = json.loads(result.stdout.strip())
                     url = data.get("url", "")
+                    number = data.get("number")
                     if url:
-                        logger.debug("Detected GitHub PR: %s", url)
-                        return ("github", url)
+                        logger.debug("Detected GitHub PR: %s (#%s)", url, number)
+                        return ("github", url, number)
             except (
                 subprocess.TimeoutExpired,
                 json.JSONDecodeError,
@@ -135,9 +144,10 @@ class ComposeCommitsStep(WorkflowStep):
                 if result.returncode == 0:
                     data = json.loads(result.stdout.strip())
                     url = data.get("web_url", "")
+                    number = data.get("iid")
                     if url:
-                        logger.debug("Detected GitLab MR: %s", url)
-                        return ("gitlab", url)
+                        logger.debug("Detected GitLab MR: %s (!%s)", url, number)
+                        return ("gitlab", url, number)
             except (
                 subprocess.TimeoutExpired,
                 json.JSONDecodeError,
@@ -146,7 +156,7 @@ class ComposeCommitsStep(WorkflowStep):
             ):
                 logger.debug("glab mr view failed or timed out")
 
-        return (None, None)
+        return (None, None, None)
 
     def _push_repo(
         self,
@@ -351,6 +361,13 @@ class ComposeCommitsStep(WorkflowStep):
             )
             return StepResult.fail(error_msg)
 
+        # Render review-context attachment once (best-effort, never blocks workflow)
+        attachment_md: str | None = None
+        try:
+            attachment_md = load_and_render_patch_attachment(context)
+        except Exception:
+            logger.debug("Failed to render patch review-context attachment", exc_info=True)
+
         # Multi-repo PR detection and push loop
         issue_id = context.require_issue_id
         succeeded: List[str] = []
@@ -358,7 +375,7 @@ class ComposeCommitsStep(WorkflowStep):
 
         for repo_path in context.repo_paths:
             # Detect platform and PR/MR URL for this repo
-            platform, pr_url = self._detect_pr_platform(repo_path, context.adw_id)
+            platform, pr_url, pr_number = self._detect_pr_platform(repo_path, context.adw_id)
 
             if not platform or not pr_url:
                 warn_msg = f"No existing PR/MR found for {repo_path}, skipping push"
@@ -415,6 +432,19 @@ class ComposeCommitsStep(WorkflowStep):
                         "repo": repo_path,
                     },
                 )
+                # Post/update review-context comment (best-effort)
+                if attachment_md and pr_number:
+                    try:
+                        if platform == "github":
+                            _post_gh_attachment_comment(repo_path, pr_number, attachment_md, env)
+                        else:
+                            _post_glab_attachment_note(repo_path, pr_number, attachment_md, env)
+                    except (subprocess.TimeoutExpired, OSError, subprocess.SubprocessError):
+                        logger.warning(
+                            "Failed to post review-context on %s for %s",
+                            platform,
+                            repo_path,
+                        )
             else:
                 errors.append(push_result.error or f"Push failed for {repo_path}")
 

--- a/src/rouge/core/workflow/steps/gh_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/gh_pull_request_step.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import shutil
-import subprocess
 from typing import ClassVar
 
 from rouge.core.utils import get_logger
@@ -15,77 +14,10 @@ from rouge.core.workflow.artifacts import (
 )
 from rouge.core.workflow.pull_request_step_base import PullRequestStepBase
 from rouge.core.workflow.step_base import WorkflowContext
-from rouge.core.workflow.step_utils import _emit_and_log
+from rouge.core.workflow.step_utils import _emit_and_log, post_gh_attachment_comment
 from rouge.core.workflow.types import StepResult
 
 _logger = get_logger(__name__)
-
-
-def _post_gh_attachment_comment(
-    repo_path: str,
-    pr_number: int,
-    body: str,
-    env: dict[str, str],
-) -> None:
-    """Post or update the Rouge review-context comment on a GitHub PR."""
-    marker = "<!-- rouge-review-context -->"
-    tagged_body = f"{marker}\n{body}"
-
-    # List existing comments and find one with our marker
-    list_cmd = [
-        "gh",
-        "pr",
-        "view",
-        str(pr_number),
-        "--json",
-        "comments",
-        "--jq",
-        '.comments[] | select(.body | startswith("<!-- rouge-review-context -->")) | .databaseId',
-    ]
-    result = subprocess.run(
-        list_cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
-    )
-
-    existing_comment_id = (
-        result.stdout.strip().split("\n")[0]
-        if result.returncode == 0 and result.stdout.strip()
-        else None
-    )
-
-    if existing_comment_id and existing_comment_id.isdigit():
-        update_cmd = [
-            "gh",
-            "api",
-            "--method",
-            "PATCH",
-            f"/repos/{{owner}}/{{repo}}/issues/comments/{existing_comment_id}",
-            "-f",
-            f"body={tagged_body}",
-        ]
-        update_result = subprocess.run(
-            update_cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
-        )
-        if update_result.returncode != 0:
-            _logger.warning(
-                "Failed to update review-context comment on PR #%d: %s",
-                pr_number,
-                update_result.stderr,
-            )
-        else:
-            _logger.info("Updated review-context comment on PR #%d", pr_number)
-    else:
-        cmd = ["gh", "pr", "comment", str(pr_number), "--body", tagged_body]
-        create_result = subprocess.run(
-            cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
-        )
-        if create_result.returncode != 0:
-            _logger.warning(
-                "Failed to post review-context comment on PR #%d: %s",
-                pr_number,
-                create_result.stderr,
-            )
-        else:
-            _logger.info("Posted review-context comment on PR #%d", pr_number)
 
 
 class GhPullRequestStep(PullRequestStepBase):
@@ -147,4 +79,4 @@ class GhPullRequestStep(PullRequestStepBase):
         return (url, number)
 
     def _post_attachment(self, repo_path: str, number: int, body: str, env: dict[str, str]) -> None:
-        _post_gh_attachment_comment(repo_path, number, body, env)
+        post_gh_attachment_comment(repo_path, number, body, env)

--- a/src/rouge/core/workflow/steps/glab_pull_request_step.py
+++ b/src/rouge/core/workflow/steps/glab_pull_request_step.py
@@ -1,8 +1,6 @@
 """Create GitLab merge request step implementation."""
 
-import json
 import re
-import subprocess
 from typing import ClassVar
 
 from rouge.core.utils import get_logger
@@ -12,74 +10,9 @@ from rouge.core.workflow.artifacts import (
     PullRequestArtifactBase,
 )
 from rouge.core.workflow.pull_request_step_base import PullRequestStepBase
+from rouge.core.workflow.step_utils import post_glab_attachment_note
 
 _logger = get_logger(__name__)
-
-
-def _post_glab_attachment_note(
-    repo_path: str,
-    mr_number: int,
-    body: str,
-    env: dict[str, str],
-) -> None:
-    """Post or update the Rouge review-context note on a GitLab MR."""
-    marker = "<!-- rouge-review-context -->"
-    tagged_body = f"{marker}\n{body}"
-
-    list_cmd = [
-        "glab",
-        "api",
-        f"projects/:id/merge_requests/{mr_number}/notes?per_page=100",
-    ]
-    result = subprocess.run(
-        list_cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
-    )
-
-    existing_note_id = None
-    if result.returncode == 0 and result.stdout.strip():
-        try:
-            notes = json.loads(result.stdout)
-            for note in notes:
-                if note.get("body", "").startswith(marker):
-                    existing_note_id = note["id"]
-                    break
-        except (ValueError, KeyError):
-            pass
-
-    if existing_note_id:
-        update_cmd = [
-            "glab",
-            "api",
-            "--method",
-            "PUT",
-            f"projects/:id/merge_requests/{mr_number}/notes/{existing_note_id}",
-            "-f",
-            f"body={tagged_body}",
-        ]
-        update_result = subprocess.run(
-            update_cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
-        )
-        if update_result.returncode != 0:
-            _logger.warning(
-                "Failed to update review-context note on MR !%d: %s",
-                mr_number,
-                update_result.stderr,
-            )
-        else:
-            _logger.info("Updated review-context note on MR !%d", mr_number)
-    else:
-        cmd = ["glab", "mr", "note", str(mr_number), "--message", tagged_body]
-        create_result = subprocess.run(
-            cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
-        )
-        if create_result.returncode != 0:
-            _logger.warning(
-                "Failed to post review-context note on MR !%d: %s",
-                mr_number,
-                create_result.stderr,
-            )
-        else:
-            _logger.info("Posted review-context note on MR !%d", mr_number)
 
 
 class GlabPullRequestStep(PullRequestStepBase):
@@ -126,4 +59,4 @@ class GlabPullRequestStep(PullRequestStepBase):
         return (url, number)
 
     def _post_attachment(self, repo_path: str, number: int, body: str, env: dict[str, str]) -> None:
-        _post_glab_attachment_note(repo_path, number, body, env)
+        post_glab_attachment_note(repo_path, number, body, env)

--- a/tests/test_dependency_contracts.py
+++ b/tests/test_dependency_contracts.py
@@ -347,9 +347,7 @@ class TestDependencySemanticsIntegration:
         # Mock environment and subprocess to avoid actual PR creation
         with patch.dict("os.environ", {"GITHUB_PAT": "test-token"}):
             with patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which") as mock_which:
-                with patch(
-                    "rouge.core.workflow.steps.gh_pull_request_step.subprocess.run"
-                ) as mock_run:
+                with patch("rouge.core.workflow.pull_request_step_base.subprocess.run") as mock_run:
                     mock_which.return_value = "/usr/bin/gh"
                     # Step calls per repo: rev-parse (branch), gh pr list,
                     # rev-parse (base branch), rev-list (delta), git push, gh pr create

--- a/tests/test_pr_attachment.py
+++ b/tests/test_pr_attachment.py
@@ -19,6 +19,7 @@ from rouge.core.workflow.step_utils import (
     _MAX_BODY_CHARS,
     _TRUNCATION_NOTICE,
     load_and_render_attachment,
+    load_and_render_patch_attachment,
     render_attachment_markdown,
 )
 from rouge.core.workflow.types import PlanData
@@ -300,5 +301,66 @@ class TestLoadAndRenderAttachment:
         ctx.artifact_store.read_artifact.side_effect = FileNotFoundError
 
         result = load_and_render_attachment(ctx)
+
+        assert result is None
+
+
+class TestLoadAndRenderPatchAttachment:
+    """Integration tests for load_and_render_patch_attachment (patch artifact loading + rendering)."""  # noqa: E501
+
+    def test_both_patch_and_plan_in_cache(self) -> None:
+        """Both fetch-patch and plan artifacts produce full output with both sections."""
+        plan = PlanData(plan="Patch plan body", summary="Patch plan summary")
+        ctx = _make_context(
+            {
+                "fetch_patch_data": {"description": "Patch spec text"},
+                "plan_data": plan,
+            }
+        )
+
+        result = load_and_render_patch_attachment(ctx)
+
+        assert result is not None
+        assert "Source Specification" in result
+        assert "Patch spec text" in result
+        assert "Implementation Plan" in result
+        assert "Patch plan body" in result
+        assert "**Summary:** Patch plan summary" in result
+
+    def test_only_patch_data(self) -> None:
+        """Output contains spec but no plan when only fetch-patch artifact is available."""
+        ctx = _make_context(
+            {
+                "fetch_patch_data": {"description": "Only patch spec"},
+            }
+        )
+        ctx.artifact_store.read_artifact.side_effect = FileNotFoundError
+
+        result = load_and_render_patch_attachment(ctx)
+
+        assert result is not None
+        assert "Source Specification" in result
+        assert "Only patch spec" in result
+        assert "Implementation Plan" not in result
+
+    def test_only_plan_data_no_patch(self) -> None:
+        """Output contains plan but no spec when only plan artifact is cached."""
+        plan = PlanData(plan="Plan without patch", summary="Plan only summary")
+        ctx = _make_context({"plan_data": plan})
+        ctx.artifact_store.read_artifact.side_effect = FileNotFoundError
+
+        result = load_and_render_patch_attachment(ctx)
+
+        assert result is not None
+        assert "Implementation Plan" in result
+        assert "Plan without patch" in result
+        assert "Source Specification" not in result
+
+    def test_neither_artifact_present(self) -> None:
+        """Returns None when both patch and plan artifact loads return None."""
+        ctx = _make_context()
+        ctx.artifact_store.read_artifact.side_effect = FileNotFoundError
+
+        result = load_and_render_patch_attachment(ctx)
 
         assert result is None

--- a/tests/test_step_registry.py
+++ b/tests/test_step_registry.py
@@ -702,9 +702,9 @@ class TestGlobalRegistry:
         registry = get_step_registry()
 
         metadata = registry.get_step_metadata_by_slug("implement-plan")
-        assert metadata is not None, (
-            "ImplementPlanStep should be registered with slug 'implement-plan'"
-        )
+        assert (
+            metadata is not None
+        ), "ImplementPlanStep should be registered with slug 'implement-plan'"
         assert metadata.dependencies == ["plan"]
         assert metadata.outputs == ["implement"]
         assert metadata.is_critical is True
@@ -714,9 +714,9 @@ class TestGlobalRegistry:
         registry = get_step_registry()
 
         metadata = registry.get_step_metadata_by_slug("implement-direct")
-        assert metadata is not None, (
-            "ImplementDirectStep should be registered with slug 'implement-direct'"
-        )
+        assert (
+            metadata is not None
+        ), "ImplementDirectStep should be registered with slug 'implement-direct'"
         assert metadata.dependencies == ["git-branch", "fetch-issue"]
         assert metadata.outputs == ["implement:direct"]
         assert metadata.dependency_kinds == {"git-branch": "ordering-only"}
@@ -743,7 +743,7 @@ class TestGlobalRegistry:
         # 'patch' producer (FetchPatchStep) are registered.
         assert issues == [], f"Registry validation issues: {issues}"
 
-    def test_patch_plan_dependency_resolution(self):
+    def test_patch_plan_dependency_resolution(self) -> None:
         """Test dependency resolution for PatchPlanStep.
 
         After decoupling, PatchPlanStep only depends on the patch artifact
@@ -764,16 +764,16 @@ class TestGlobalRegistry:
         deps = registry.resolve_dependencies(patch_plan_step_name)
 
         # Should only include FetchPatchStep (produces patch artifact)
-        assert any("Fetching pending patch" in dep for dep in deps), (
-            "Should depend on FetchPatchStep"
-        )
+        assert any(
+            "Fetching pending patch" in dep for dep in deps
+        ), "Should depend on FetchPatchStep"
         # Should NOT depend on FetchIssueStep or PlanStep (decoupled)
-        assert not any("Fetching issue" in dep for dep in deps), (
-            "Should not depend on FetchIssueStep"
-        )
-        assert not any("Building implementation plan" in dep for dep in deps), (
-            "Should not depend on PlanStep"
-        )
+        assert not any(
+            "Fetching issue" in dep for dep in deps
+        ), "Should not depend on FetchIssueStep"
+        assert not any(
+            "Building implementation plan" in dep for dep in deps
+        ), "Should not depend on PlanStep"
 
 
 class TestRegistryContractConstraints:
@@ -816,9 +816,9 @@ class TestRegistryContractConstraints:
         implement_meta = registry.get_step_metadata_by_slug("implement-plan")
 
         assert implement_meta is not None, "ImplementPlanStep must be registered"
-        assert "plan" in implement_meta.dependencies, (
-            "ImplementPlanStep must declare plan as a dependency"
-        )
+        assert (
+            "plan" in implement_meta.dependencies
+        ), "ImplementPlanStep must declare plan as a dependency"
         # plan must NOT appear in dependency_kinds — absence means 'required'
         assert "plan" not in implement_meta.dependency_kinds, (
             "ImplementPlanStep's plan dependency should be implicitly required "
@@ -850,27 +850,27 @@ class TestRegistryContractConstraints:
         # gh-pull-request: compose-request is optional
         gh_meta = registry.get_step_metadata_by_slug("gh-pull-request")
         assert gh_meta is not None, "gh-pull-request step must be registered"
-        assert gh_meta.dependency_kinds.get("compose-request") == "optional", (
-            "gh-pull-request must declare compose-request as optional"
-        )
+        assert (
+            gh_meta.dependency_kinds.get("compose-request") == "optional"
+        ), "gh-pull-request must declare compose-request as optional"
 
         # glab-pull-request: compose-request is optional
         glab_meta = registry.get_step_metadata_by_slug("glab-pull-request")
         assert glab_meta is not None, "glab-pull-request step must be registered"
-        assert glab_meta.dependency_kinds.get("compose-request") == "optional", (
-            "glab-pull-request must declare compose-request as optional"
-        )
+        assert (
+            glab_meta.dependency_kinds.get("compose-request") == "optional"
+        ), "glab-pull-request must declare compose-request as optional"
 
         # code-quality: implement is optional (reads affected repos from implement artifact)
         cq_meta = registry.get_step_metadata_by_slug("code-quality")
         assert cq_meta is not None, "code-quality step must be registered"
-        assert cq_meta.dependency_kinds.get("implement") == "optional", (
-            "code-quality must declare implement as optional"
-        )
+        assert (
+            cq_meta.dependency_kinds.get("implement") == "optional"
+        ), "code-quality must declare implement as optional"
 
         # compose-request: implement is optional
         cr_meta = registry.get_step_metadata_by_slug("compose-request")
         assert cr_meta is not None, "compose-request step must be registered"
-        assert cr_meta.dependency_kinds.get("implement") == "optional", (
-            "compose-request must declare implement as optional"
-        )
+        assert (
+            cr_meta.dependency_kinds.get("implement") == "optional"
+        ), "compose-request must declare implement as optional"

--- a/tests/test_step_registry.py
+++ b/tests/test_step_registry.py
@@ -662,12 +662,13 @@ class TestGlobalRegistry:
         assert metadata.outputs == ["plan"]
         assert metadata.is_critical is True
 
-    def test_update_pr_commits_step_registration(self):
+    def test_update_pr_commits_step_registration(self) -> None:
         """Test ComposeCommitsStep is registered with correct metadata.
 
         After decoupling, ComposeCommitsStep detects PRs via gh/glab CLI
-        rather than loading parent PullRequestArtifact, so it has no artifact
-        dependencies.
+        rather than loading parent PullRequestArtifact.  It declares
+        fetch-patch and plan as optional dependencies for best-effort
+        review-context posting.
         """
         registry = get_step_registry()
 
@@ -682,7 +683,7 @@ class TestGlobalRegistry:
 
         metadata = registry.get_step_metadata(update_pr_commits_step_name)
         assert metadata is not None
-        assert metadata.dependencies == []
+        assert metadata.dependencies == ["fetch-patch", "plan"]
         assert metadata.outputs == ["compose-commits"]
         assert metadata.is_critical is False
 
@@ -701,9 +702,9 @@ class TestGlobalRegistry:
         registry = get_step_registry()
 
         metadata = registry.get_step_metadata_by_slug("implement-plan")
-        assert (
-            metadata is not None
-        ), "ImplementPlanStep should be registered with slug 'implement-plan'"
+        assert metadata is not None, (
+            "ImplementPlanStep should be registered with slug 'implement-plan'"
+        )
         assert metadata.dependencies == ["plan"]
         assert metadata.outputs == ["implement"]
         assert metadata.is_critical is True
@@ -713,9 +714,9 @@ class TestGlobalRegistry:
         registry = get_step_registry()
 
         metadata = registry.get_step_metadata_by_slug("implement-direct")
-        assert (
-            metadata is not None
-        ), "ImplementDirectStep should be registered with slug 'implement-direct'"
+        assert metadata is not None, (
+            "ImplementDirectStep should be registered with slug 'implement-direct'"
+        )
         assert metadata.dependencies == ["git-branch", "fetch-issue"]
         assert metadata.outputs == ["implement:direct"]
         assert metadata.dependency_kinds == {"git-branch": "ordering-only"}
@@ -763,16 +764,16 @@ class TestGlobalRegistry:
         deps = registry.resolve_dependencies(patch_plan_step_name)
 
         # Should only include FetchPatchStep (produces patch artifact)
-        assert any(
-            "Fetching pending patch" in dep for dep in deps
-        ), "Should depend on FetchPatchStep"
+        assert any("Fetching pending patch" in dep for dep in deps), (
+            "Should depend on FetchPatchStep"
+        )
         # Should NOT depend on FetchIssueStep or PlanStep (decoupled)
-        assert not any(
-            "Fetching issue" in dep for dep in deps
-        ), "Should not depend on FetchIssueStep"
-        assert not any(
-            "Building implementation plan" in dep for dep in deps
-        ), "Should not depend on PlanStep"
+        assert not any("Fetching issue" in dep for dep in deps), (
+            "Should not depend on FetchIssueStep"
+        )
+        assert not any("Building implementation plan" in dep for dep in deps), (
+            "Should not depend on PlanStep"
+        )
 
 
 class TestRegistryContractConstraints:
@@ -815,9 +816,9 @@ class TestRegistryContractConstraints:
         implement_meta = registry.get_step_metadata_by_slug("implement-plan")
 
         assert implement_meta is not None, "ImplementPlanStep must be registered"
-        assert (
-            "plan" in implement_meta.dependencies
-        ), "ImplementPlanStep must declare plan as a dependency"
+        assert "plan" in implement_meta.dependencies, (
+            "ImplementPlanStep must declare plan as a dependency"
+        )
         # plan must NOT appear in dependency_kinds — absence means 'required'
         assert "plan" not in implement_meta.dependency_kinds, (
             "ImplementPlanStep's plan dependency should be implicitly required "
@@ -849,27 +850,27 @@ class TestRegistryContractConstraints:
         # gh-pull-request: compose-request is optional
         gh_meta = registry.get_step_metadata_by_slug("gh-pull-request")
         assert gh_meta is not None, "gh-pull-request step must be registered"
-        assert (
-            gh_meta.dependency_kinds.get("compose-request") == "optional"
-        ), "gh-pull-request must declare compose-request as optional"
+        assert gh_meta.dependency_kinds.get("compose-request") == "optional", (
+            "gh-pull-request must declare compose-request as optional"
+        )
 
         # glab-pull-request: compose-request is optional
         glab_meta = registry.get_step_metadata_by_slug("glab-pull-request")
         assert glab_meta is not None, "glab-pull-request step must be registered"
-        assert (
-            glab_meta.dependency_kinds.get("compose-request") == "optional"
-        ), "glab-pull-request must declare compose-request as optional"
+        assert glab_meta.dependency_kinds.get("compose-request") == "optional", (
+            "glab-pull-request must declare compose-request as optional"
+        )
 
         # code-quality: implement is optional (reads affected repos from implement artifact)
         cq_meta = registry.get_step_metadata_by_slug("code-quality")
         assert cq_meta is not None, "code-quality step must be registered"
-        assert (
-            cq_meta.dependency_kinds.get("implement") == "optional"
-        ), "code-quality must declare implement as optional"
+        assert cq_meta.dependency_kinds.get("implement") == "optional", (
+            "code-quality must declare implement as optional"
+        )
 
         # compose-request: implement is optional
         cr_meta = registry.get_step_metadata_by_slug("compose-request")
         assert cr_meta is not None, "compose-request step must be registered"
-        assert (
-            cr_meta.dependency_kinds.get("implement") == "optional"
-        ), "compose-request must declare implement as optional"
+        assert cr_meta.dependency_kinds.get("implement") == "optional", (
+            "compose-request must declare implement as optional"
+        )

--- a/tests/test_update_pr_commits_step.py
+++ b/tests/test_update_pr_commits_step.py
@@ -616,7 +616,7 @@ class TestPatchReviewContext:
         "rouge.core.workflow.step_utils.emit_comment_from_payload",
         return_value=("success", "ok"),
     )
-    @patch("rouge.core.workflow.steps.compose_commits_step._post_gh_attachment_comment")
+    @patch("rouge.core.workflow.steps.compose_commits_step.post_gh_attachment_comment")
     @patch("rouge.core.workflow.steps.compose_commits_step.load_and_render_patch_attachment")
     @patch("subprocess.run")
     @patch("rouge.core.workflow.steps.compose_commits_step.parse_and_validate_json")
@@ -634,7 +634,7 @@ class TestPatchReviewContext:
         monkeypatch,
         mock_context,
     ) -> None:
-        """After a successful push on GitHub, _post_gh_attachment_comment is called."""
+        """After a successful push on GitHub, post_gh_attachment_comment is called."""
         self._mock_compose_commits(mock_request, mock_exec, mock_parse)
         mock_load_attachment.return_value = "## Review Context\nSome markdown"
         mock_subprocess.side_effect = self._subprocess_github(pr_number=42)
@@ -658,7 +658,7 @@ class TestPatchReviewContext:
         "rouge.core.workflow.step_utils.emit_comment_from_payload",
         return_value=("success", "ok"),
     )
-    @patch("rouge.core.workflow.steps.compose_commits_step._post_glab_attachment_note")
+    @patch("rouge.core.workflow.steps.compose_commits_step.post_glab_attachment_note")
     @patch("rouge.core.workflow.steps.compose_commits_step.load_and_render_patch_attachment")
     @patch("subprocess.run")
     @patch("rouge.core.workflow.steps.compose_commits_step.parse_and_validate_json")
@@ -676,7 +676,7 @@ class TestPatchReviewContext:
         monkeypatch,
         mock_context,
     ) -> None:
-        """After a successful push on GitLab, _post_glab_attachment_note is called."""
+        """After a successful push on GitLab, post_glab_attachment_note is called."""
         self._mock_compose_commits(mock_request, mock_exec, mock_parse)
         mock_load_attachment.return_value = "## Review Context\nGitLab markdown"
         mock_subprocess.side_effect = self._subprocess_gitlab(mr_number=7)
@@ -699,7 +699,7 @@ class TestPatchReviewContext:
         "rouge.core.workflow.step_utils.emit_comment_from_payload",
         return_value=("success", "ok"),
     )
-    @patch("rouge.core.workflow.steps.compose_commits_step._post_gh_attachment_comment")
+    @patch("rouge.core.workflow.steps.compose_commits_step.post_gh_attachment_comment")
     @patch("rouge.core.workflow.steps.compose_commits_step.load_and_render_patch_attachment")
     @patch("subprocess.run")
     @patch("rouge.core.workflow.steps.compose_commits_step.parse_and_validate_json")
@@ -717,7 +717,7 @@ class TestPatchReviewContext:
         monkeypatch,
         mock_context,
     ) -> None:
-        """If _post_gh_attachment_comment raises OSError, the step still succeeds."""
+        """If post_gh_attachment_comment raises OSError, the step still succeeds."""
         self._mock_compose_commits(mock_request, mock_exec, mock_parse)
         mock_load_attachment.return_value = "## Review Context"
         mock_post_gh.side_effect = OSError("network error")
@@ -736,8 +736,8 @@ class TestPatchReviewContext:
         "rouge.core.workflow.step_utils.emit_comment_from_payload",
         return_value=("success", "ok"),
     )
-    @patch("rouge.core.workflow.steps.compose_commits_step._post_gh_attachment_comment")
-    @patch("rouge.core.workflow.steps.compose_commits_step._post_glab_attachment_note")
+    @patch("rouge.core.workflow.steps.compose_commits_step.post_gh_attachment_comment")
+    @patch("rouge.core.workflow.steps.compose_commits_step.post_glab_attachment_note")
     @patch("rouge.core.workflow.steps.compose_commits_step.load_and_render_patch_attachment")
     @patch("subprocess.run")
     @patch("rouge.core.workflow.steps.compose_commits_step.parse_and_validate_json")
@@ -775,8 +775,8 @@ class TestPatchReviewContext:
         "rouge.core.workflow.step_utils.emit_comment_from_payload",
         return_value=("success", "ok"),
     )
-    @patch("rouge.core.workflow.steps.compose_commits_step._post_gh_attachment_comment")
-    @patch("rouge.core.workflow.steps.compose_commits_step._post_glab_attachment_note")
+    @patch("rouge.core.workflow.steps.compose_commits_step.post_gh_attachment_comment")
+    @patch("rouge.core.workflow.steps.compose_commits_step.post_glab_attachment_note")
     @patch("rouge.core.workflow.steps.compose_commits_step.load_and_render_patch_attachment")
     @patch("subprocess.run")
     @patch("rouge.core.workflow.steps.compose_commits_step.parse_and_validate_json")

--- a/tests/test_update_pr_commits_step.py
+++ b/tests/test_update_pr_commits_step.py
@@ -6,6 +6,7 @@ verifying that the step works independently without loading parent artifacts.
 
 import json
 import subprocess
+from typing import Callable
 from unittest.mock import Mock, patch
 
 import pytest
@@ -261,7 +262,7 @@ class TestComposeCommits:
             # gh pr view for platform detection
             return Mock(
                 returncode=0,
-                stdout=json.dumps({"url": "https://github.com/org/repo/pull/1"}),
+                stdout=json.dumps({"url": "https://github.com/org/repo/pull/1", "number": 1}),
             )
 
         mock_subprocess.side_effect = subprocess_side_effect
@@ -430,7 +431,7 @@ class TestComposeCommitsMultiRepo:
             # gh pr view for platform detection
             return Mock(
                 returncode=0,
-                stdout=json.dumps({"url": "https://github.com/org/repo/pull/1"}),
+                stdout=json.dumps({"url": "https://github.com/org/repo/pull/1", "number": 1}),
             )
 
         mock_subprocess.side_effect = subprocess_side_effect
@@ -546,7 +547,7 @@ class TestPatchReviewContext:
     # -- helpers ----------------------------------------------------------
 
     @staticmethod
-    def _mock_compose_commits(mock_request, mock_exec, mock_parse):
+    def _mock_compose_commits(mock_request, mock_exec, mock_parse) -> None:
         """Wire up mocks so compose-commits succeeds."""
         mock_request_instance = Mock()
         mock_request_instance.model_dump_json.return_value = "{}"
@@ -563,7 +564,7 @@ class TestPatchReviewContext:
         )
 
     @staticmethod
-    def _subprocess_github(pr_number=42):
+    def _subprocess_github(pr_number: int = 42) -> Callable[..., Mock]:
         """Return a subprocess side-effect for a GitHub repo with a PR."""
 
         def _side_effect(cmd, **kwargs):
@@ -586,7 +587,7 @@ class TestPatchReviewContext:
         return _side_effect
 
     @staticmethod
-    def _subprocess_gitlab(mr_number=7):
+    def _subprocess_gitlab(mr_number: int = 7) -> Callable[..., Mock]:
         """Return a subprocess side-effect for a GitLab repo with an MR."""
 
         def _side_effect(cmd, **kwargs):

--- a/tests/test_update_pr_commits_step.py
+++ b/tests/test_update_pr_commits_step.py
@@ -6,7 +6,7 @@ verifying that the step works independently without loading parent artifacts.
 
 import json
 import subprocess
-from typing import Callable
+from typing import Any, Callable, Sequence
 from unittest.mock import Mock, patch
 
 import pytest
@@ -136,7 +136,7 @@ class TestDetectPrPlatform:
         """Test handles timeout from gh command gracefully."""
         step = ComposeCommitsStep()
 
-        def raise_timeout(*_args, **_kwargs):
+        def raise_timeout(*_args: Any, **_kwargs: Any) -> None:
             raise subprocess.TimeoutExpired(cmd="gh", timeout=30)
 
         monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "github")
@@ -254,7 +254,7 @@ class TestComposeCommits:
         branch_result = Mock(returncode=0, stdout="feature-branch\n", stderr="")
         push_result = Mock(returncode=0, stdout="", stderr="")
 
-        def subprocess_side_effect(cmd, **_kwargs):
+        def subprocess_side_effect(cmd: Sequence[str], **_kwargs: Any) -> Mock:
             if cmd == ["git", "symbolic-ref", "--short", "HEAD"]:
                 return branch_result
             if cmd[0] == "git" and cmd[1] == "push":
@@ -423,7 +423,7 @@ class TestComposeCommitsMultiRepo:
         mock_exec.return_value = mock_response
         mock_parse.return_value = mock_parse_response
 
-        def subprocess_side_effect(cmd, **kwargs):
+        def subprocess_side_effect(cmd: Sequence[str], **kwargs: Any) -> Mock:
             if cmd == ["git", "symbolic-ref", "--short", "HEAD"]:
                 return Mock(returncode=0, stdout="feature-branch\n", stderr="")
             if cmd[0] == "git" and cmd[1] == "push":
@@ -491,7 +491,7 @@ class TestComposeCommitsMultiRepo:
         mock_exec.return_value = mock_response
         mock_parse.return_value = mock_parse_response
 
-        def subprocess_side_effect(cmd, **kwargs):
+        def subprocess_side_effect(cmd: Sequence[str], **kwargs: Any) -> Mock:
             cwd = kwargs.get("cwd", "")
             if cmd == ["gh", "pr", "view", "--json", "url,number"]:
                 # Only /repo/with-pr has a PR
@@ -547,7 +547,7 @@ class TestPatchReviewContext:
     # -- helpers ----------------------------------------------------------
 
     @staticmethod
-    def _mock_compose_commits(mock_request, mock_exec, mock_parse) -> None:
+    def _mock_compose_commits(mock_request: Mock, mock_exec: Mock, mock_parse: Mock) -> None:
         """Wire up mocks so compose-commits succeeds."""
         mock_request_instance = Mock()
         mock_request_instance.model_dump_json.return_value = "{}"
@@ -567,7 +567,7 @@ class TestPatchReviewContext:
     def _subprocess_github(pr_number: int = 42) -> Callable[..., Mock]:
         """Return a subprocess side-effect for a GitHub repo with a PR."""
 
-        def _side_effect(cmd, **kwargs):
+        def _side_effect(cmd: Sequence[str], **kwargs: Any) -> Mock:
             if cmd == ["gh", "pr", "view", "--json", "url,number"]:
                 return Mock(
                     returncode=0,
@@ -590,7 +590,7 @@ class TestPatchReviewContext:
     def _subprocess_gitlab(mr_number: int = 7) -> Callable[..., Mock]:
         """Return a subprocess side-effect for a GitLab repo with an MR."""
 
-        def _side_effect(cmd, **kwargs):
+        def _side_effect(cmd: Sequence[str], **kwargs: Any) -> Mock:
             if cmd == ["glab", "mr", "view", "--output", "json"]:
                 return Mock(
                     returncode=0,
@@ -801,7 +801,7 @@ class TestPatchReviewContext:
         mock_load_attachment.return_value = "## Review Context"
 
         # gh pr view returns url but no number field
-        def _side_effect(cmd, **kwargs):
+        def _side_effect(cmd: Sequence[str], **kwargs: Any) -> Mock:
             if cmd == ["gh", "pr", "view", "--json", "url,number"]:
                 return Mock(
                     returncode=0,

--- a/tests/test_update_pr_commits_step.py
+++ b/tests/test_update_pr_commits_step.py
@@ -35,80 +35,87 @@ class TestDetectPrPlatform:
     def test_detects_github_pr_via_gh(self, mock_run, monkeypatch) -> None:
         """Test detection of GitHub PR using gh CLI."""
         step = ComposeCommitsStep()
-        gh_output = json.dumps({"url": "https://github.com/org/repo/pull/42"})
+        gh_output = json.dumps({"url": "https://github.com/org/repo/pull/42", "number": 42})
         mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = gh_output
         mock_run.return_value = mock_result
 
         monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "github")
-        platform, url = step._detect_pr_platform("/fake/repo", "test-adw-id")
+        platform, url, number = step._detect_pr_platform("/fake/repo", "test-adw-id")
 
         assert platform == "github"
         assert url == "https://github.com/org/repo/pull/42"
+        assert number == 42
         # Verify gh was called with correct args
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
-        assert cmd == ["gh", "pr", "view", "--json", "url"]
+        assert cmd == ["gh", "pr", "view", "--json", "url,number"]
 
     @patch("subprocess.run")
     def test_detects_gitlab_mr_via_glab(self, mock_run, monkeypatch) -> None:
         """Test detection of GitLab MR using glab CLI."""
         step = ComposeCommitsStep()
-        glab_output = json.dumps({"web_url": "https://gitlab.com/org/repo/-/merge_requests/7"})
+        glab_output = json.dumps(
+            {"web_url": "https://gitlab.com/org/repo/-/merge_requests/7", "iid": 7}
+        )
         mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = glab_output
         mock_run.return_value = mock_result
 
         monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "gitlab")
-        platform, url = step._detect_pr_platform("/fake/repo", "test-adw-id")
+        platform, url, number = step._detect_pr_platform("/fake/repo", "test-adw-id")
 
         assert platform == "gitlab"
         assert url == "https://gitlab.com/org/repo/-/merge_requests/7"
+        assert number == 7
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
         assert cmd == ["glab", "mr", "view", "--output", "json"]
 
     @patch("subprocess.run")
     def test_returns_none_when_env_missing(self, mock_run, monkeypatch) -> None:
-        """Test returns (None, None) when DEV_SEC_OPS_PLATFORM is unset."""
+        """Test returns (None, None, None) when DEV_SEC_OPS_PLATFORM is unset."""
         step = ComposeCommitsStep()
 
         monkeypatch.delenv("DEV_SEC_OPS_PLATFORM", raising=False)
-        platform, url = step._detect_pr_platform("/fake/repo", "test-adw-id")
+        platform, url, number = step._detect_pr_platform("/fake/repo", "test-adw-id")
 
         assert platform is None
         assert url is None
+        assert number is None
         mock_run.assert_not_called()
 
     @patch("subprocess.run")
     def test_returns_none_when_env_invalid(self, mock_run, monkeypatch) -> None:
-        """Test returns (None, None) when DEV_SEC_OPS_PLATFORM is invalid."""
+        """Test returns (None, None, None) when DEV_SEC_OPS_PLATFORM is invalid."""
         step = ComposeCommitsStep()
 
         monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "bitbucket")
-        platform, url = step._detect_pr_platform("/fake/repo", "test-adw-id")
+        platform, url, number = step._detect_pr_platform("/fake/repo", "test-adw-id")
 
         assert platform is None
         assert url is None
+        assert number is None
         mock_run.assert_not_called()
 
     @patch("subprocess.run")
     def test_returns_none_when_cli_missing(self, mock_run, monkeypatch) -> None:
-        """Test returns (None, None) when CLI is missing."""
+        """Test returns (None, None, None) when CLI is missing."""
         step = ComposeCommitsStep()
 
         monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "github")
         mock_run.side_effect = FileNotFoundError
-        platform, url = step._detect_pr_platform("/fake/repo", "test-adw-id")
+        platform, url, number = step._detect_pr_platform("/fake/repo", "test-adw-id")
 
         assert platform is None
         assert url is None
+        assert number is None
 
     @patch("subprocess.run")
     def test_returns_none_when_github_cli_fails(self, mock_run, monkeypatch) -> None:
-        """Test returns (None, None) when the selected CLI command fails."""
+        """Test returns (None, None, None) when the selected CLI command fails."""
         step = ComposeCommitsStep()
 
         fail_result = Mock()
@@ -117,10 +124,11 @@ class TestDetectPrPlatform:
         mock_run.return_value = fail_result
 
         monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "github")
-        platform, url = step._detect_pr_platform("/fake/repo", "test-adw-id")
+        platform, url, number = step._detect_pr_platform("/fake/repo", "test-adw-id")
 
         assert platform is None
         assert url is None
+        assert number is None
 
     @patch("subprocess.run")
     def test_handles_gh_timeout(self, mock_run, monkeypatch) -> None:
@@ -132,10 +140,11 @@ class TestDetectPrPlatform:
 
         monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "github")
         mock_run.side_effect = raise_timeout
-        platform, url = step._detect_pr_platform("/fake/repo", "test-adw-id")
+        platform, url, number = step._detect_pr_platform("/fake/repo", "test-adw-id")
 
         assert platform is None
         assert url is None
+        assert number is None
 
     @patch("subprocess.run")
     def test_handles_invalid_json_from_gh(self, mock_run, monkeypatch) -> None:
@@ -148,10 +157,11 @@ class TestDetectPrPlatform:
         mock_run.return_value = mock_result
 
         monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "github")
-        platform, url = step._detect_pr_platform("/fake/repo", "test-adw-id")
+        platform, url, number = step._detect_pr_platform("/fake/repo", "test-adw-id")
 
         assert platform is None
         assert url is None
+        assert number is None
 
 
 class TestRunWhenPlatformMissing:
@@ -482,7 +492,7 @@ class TestComposeCommitsMultiRepo:
 
         def subprocess_side_effect(cmd, **kwargs):
             cwd = kwargs.get("cwd", "")
-            if cmd == ["gh", "pr", "view", "--json", "url"]:
+            if cmd == ["gh", "pr", "view", "--json", "url,number"]:
                 # Only /repo/with-pr has a PR
                 if cwd == "/repo/with-pr":
                     return Mock(
@@ -528,3 +538,288 @@ class TestUpdatePRCommitsStepProperties:
         """Test step is not critical."""
         step = ComposeCommitsStep()
         assert step.is_critical is False
+
+
+class TestPatchReviewContext:
+    """Tests for review-context posting after successful push."""
+
+    # -- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _mock_compose_commits(mock_request, mock_exec, mock_parse):
+        """Wire up mocks so compose-commits succeeds."""
+        mock_request_instance = Mock()
+        mock_request_instance.model_dump_json.return_value = "{}"
+        mock_request.return_value = mock_request_instance
+
+        mock_exec.return_value = Mock(
+            success=True,
+            output='{"output": "compose-commits", "summary": "s", "commits": []}',
+        )
+        mock_parse.return_value = Mock(
+            success=True,
+            data={"output": "compose-commits", "summary": "s", "commits": []},
+            error=None,
+        )
+
+    @staticmethod
+    def _subprocess_github(pr_number=42):
+        """Return a subprocess side-effect for a GitHub repo with a PR."""
+
+        def _side_effect(cmd, **kwargs):
+            if cmd == ["gh", "pr", "view", "--json", "url,number"]:
+                return Mock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        {
+                            "url": "https://github.com/org/repo/pull/%d" % pr_number,
+                            "number": pr_number,
+                        }
+                    ),
+                )
+            if cmd == ["git", "symbolic-ref", "--short", "HEAD"]:
+                return Mock(returncode=0, stdout="feature-branch\n", stderr="")
+            if cmd[0] == "git" and cmd[1] == "push":
+                return Mock(returncode=0, stdout="", stderr="")
+            return Mock(returncode=1, stdout="", stderr="")
+
+        return _side_effect
+
+    @staticmethod
+    def _subprocess_gitlab(mr_number=7):
+        """Return a subprocess side-effect for a GitLab repo with an MR."""
+
+        def _side_effect(cmd, **kwargs):
+            if cmd == ["glab", "mr", "view", "--output", "json"]:
+                return Mock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        {
+                            "web_url": (
+                                "https://gitlab.com/org/repo/-/merge_requests/%d" % mr_number
+                            ),
+                            "iid": mr_number,
+                        }
+                    ),
+                )
+            if cmd == ["git", "symbolic-ref", "--short", "HEAD"]:
+                return Mock(returncode=0, stdout="feature-branch\n", stderr="")
+            if cmd[0] == "git" and cmd[1] == "push":
+                return Mock(returncode=0, stdout="", stderr="")
+            return Mock(returncode=1, stdout="", stderr="")
+
+        return _side_effect
+
+    # -- tests ------------------------------------------------------------
+
+    @patch(
+        "rouge.core.workflow.step_utils.emit_comment_from_payload",
+        return_value=("success", "ok"),
+    )
+    @patch("rouge.core.workflow.steps.compose_commits_step._post_gh_attachment_comment")
+    @patch("rouge.core.workflow.steps.compose_commits_step.load_and_render_patch_attachment")
+    @patch("subprocess.run")
+    @patch("rouge.core.workflow.steps.compose_commits_step.parse_and_validate_json")
+    @patch("rouge.core.workflow.steps.compose_commits_step.execute_template")
+    @patch("rouge.core.workflow.steps.compose_commits_step.ClaudeAgentTemplateRequest")
+    def test_review_context_posted_after_push_github(
+        self,
+        mock_request,
+        mock_exec,
+        mock_parse,
+        mock_subprocess,
+        mock_load_attachment,
+        mock_post_gh,
+        _mock_emit,
+        monkeypatch,
+        mock_context,
+    ) -> None:
+        """After a successful push on GitHub, _post_gh_attachment_comment is called."""
+        self._mock_compose_commits(mock_request, mock_exec, mock_parse)
+        mock_load_attachment.return_value = "## Review Context\nSome markdown"
+        mock_subprocess.side_effect = self._subprocess_github(pr_number=42)
+
+        monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "github")
+        monkeypatch.setenv("GITHUB_PAT", "fake-token")
+
+        step = ComposeCommitsStep()
+        result = step.run(mock_context)
+
+        assert result.success is True
+        mock_post_gh.assert_called_once()
+        call_args = mock_post_gh.call_args
+        assert call_args[0][0] == "/repo"  # repo_path
+        assert call_args[0][1] == 42  # pr_number
+        assert call_args[0][2] == "## Review Context\nSome markdown"  # body
+        # Fourth arg is the env dict containing GH_TOKEN
+        assert call_args[0][3]["GH_TOKEN"] == "fake-token"
+
+    @patch(
+        "rouge.core.workflow.step_utils.emit_comment_from_payload",
+        return_value=("success", "ok"),
+    )
+    @patch("rouge.core.workflow.steps.compose_commits_step._post_glab_attachment_note")
+    @patch("rouge.core.workflow.steps.compose_commits_step.load_and_render_patch_attachment")
+    @patch("subprocess.run")
+    @patch("rouge.core.workflow.steps.compose_commits_step.parse_and_validate_json")
+    @patch("rouge.core.workflow.steps.compose_commits_step.execute_template")
+    @patch("rouge.core.workflow.steps.compose_commits_step.ClaudeAgentTemplateRequest")
+    def test_review_context_posted_after_push_gitlab(
+        self,
+        mock_request,
+        mock_exec,
+        mock_parse,
+        mock_subprocess,
+        mock_load_attachment,
+        mock_post_glab,
+        _mock_emit,
+        monkeypatch,
+        mock_context,
+    ) -> None:
+        """After a successful push on GitLab, _post_glab_attachment_note is called."""
+        self._mock_compose_commits(mock_request, mock_exec, mock_parse)
+        mock_load_attachment.return_value = "## Review Context\nGitLab markdown"
+        mock_subprocess.side_effect = self._subprocess_gitlab(mr_number=7)
+
+        monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "gitlab")
+        monkeypatch.setenv("GITLAB_PAT", "fake-token")
+
+        step = ComposeCommitsStep()
+        result = step.run(mock_context)
+
+        assert result.success is True
+        mock_post_glab.assert_called_once()
+        call_args = mock_post_glab.call_args
+        assert call_args[0][0] == "/repo"  # repo_path
+        assert call_args[0][1] == 7  # mr number (iid)
+        assert call_args[0][2] == "## Review Context\nGitLab markdown"  # body
+        assert call_args[0][3]["GITLAB_TOKEN"] == "fake-token"
+
+    @patch(
+        "rouge.core.workflow.step_utils.emit_comment_from_payload",
+        return_value=("success", "ok"),
+    )
+    @patch("rouge.core.workflow.steps.compose_commits_step._post_gh_attachment_comment")
+    @patch("rouge.core.workflow.steps.compose_commits_step.load_and_render_patch_attachment")
+    @patch("subprocess.run")
+    @patch("rouge.core.workflow.steps.compose_commits_step.parse_and_validate_json")
+    @patch("rouge.core.workflow.steps.compose_commits_step.execute_template")
+    @patch("rouge.core.workflow.steps.compose_commits_step.ClaudeAgentTemplateRequest")
+    def test_review_context_failure_does_not_fail_step(
+        self,
+        mock_request,
+        mock_exec,
+        mock_parse,
+        mock_subprocess,
+        mock_load_attachment,
+        mock_post_gh,
+        _mock_emit,
+        monkeypatch,
+        mock_context,
+    ) -> None:
+        """If _post_gh_attachment_comment raises OSError, the step still succeeds."""
+        self._mock_compose_commits(mock_request, mock_exec, mock_parse)
+        mock_load_attachment.return_value = "## Review Context"
+        mock_post_gh.side_effect = OSError("network error")
+        mock_subprocess.side_effect = self._subprocess_github(pr_number=42)
+
+        monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "github")
+        monkeypatch.setenv("GITHUB_PAT", "fake-token")
+
+        step = ComposeCommitsStep()
+        result = step.run(mock_context)
+
+        assert result.success is True
+        mock_post_gh.assert_called_once()
+
+    @patch(
+        "rouge.core.workflow.step_utils.emit_comment_from_payload",
+        return_value=("success", "ok"),
+    )
+    @patch("rouge.core.workflow.steps.compose_commits_step._post_gh_attachment_comment")
+    @patch("rouge.core.workflow.steps.compose_commits_step._post_glab_attachment_note")
+    @patch("rouge.core.workflow.steps.compose_commits_step.load_and_render_patch_attachment")
+    @patch("subprocess.run")
+    @patch("rouge.core.workflow.steps.compose_commits_step.parse_and_validate_json")
+    @patch("rouge.core.workflow.steps.compose_commits_step.execute_template")
+    @patch("rouge.core.workflow.steps.compose_commits_step.ClaudeAgentTemplateRequest")
+    def test_review_context_skipped_when_no_attachment(
+        self,
+        mock_request,
+        mock_exec,
+        mock_parse,
+        mock_subprocess,
+        mock_load_attachment,
+        mock_post_glab,
+        mock_post_gh,
+        _mock_emit,
+        monkeypatch,
+        mock_context,
+    ) -> None:
+        """When load_and_render_patch_attachment returns None, posting is skipped."""
+        self._mock_compose_commits(mock_request, mock_exec, mock_parse)
+        mock_load_attachment.return_value = None
+        mock_subprocess.side_effect = self._subprocess_github(pr_number=42)
+
+        monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "github")
+        monkeypatch.setenv("GITHUB_PAT", "fake-token")
+
+        step = ComposeCommitsStep()
+        result = step.run(mock_context)
+
+        assert result.success is True
+        mock_post_gh.assert_not_called()
+        mock_post_glab.assert_not_called()
+
+    @patch(
+        "rouge.core.workflow.step_utils.emit_comment_from_payload",
+        return_value=("success", "ok"),
+    )
+    @patch("rouge.core.workflow.steps.compose_commits_step._post_gh_attachment_comment")
+    @patch("rouge.core.workflow.steps.compose_commits_step._post_glab_attachment_note")
+    @patch("rouge.core.workflow.steps.compose_commits_step.load_and_render_patch_attachment")
+    @patch("subprocess.run")
+    @patch("rouge.core.workflow.steps.compose_commits_step.parse_and_validate_json")
+    @patch("rouge.core.workflow.steps.compose_commits_step.execute_template")
+    @patch("rouge.core.workflow.steps.compose_commits_step.ClaudeAgentTemplateRequest")
+    def test_review_context_skipped_when_no_pr_number(
+        self,
+        mock_request,
+        mock_exec,
+        mock_parse,
+        mock_subprocess,
+        mock_load_attachment,
+        mock_post_glab,
+        mock_post_gh,
+        _mock_emit,
+        monkeypatch,
+        mock_context,
+    ) -> None:
+        """When _detect_pr_platform returns no pr_number, posting is skipped."""
+        self._mock_compose_commits(mock_request, mock_exec, mock_parse)
+        mock_load_attachment.return_value = "## Review Context"
+
+        # gh pr view returns url but no number field
+        def _side_effect(cmd, **kwargs):
+            if cmd == ["gh", "pr", "view", "--json", "url,number"]:
+                return Mock(
+                    returncode=0,
+                    stdout=json.dumps({"url": "https://github.com/org/repo/pull/99"}),
+                )
+            if cmd == ["git", "symbolic-ref", "--short", "HEAD"]:
+                return Mock(returncode=0, stdout="feature-branch\n", stderr="")
+            if cmd[0] == "git" and cmd[1] == "push":
+                return Mock(returncode=0, stdout="", stderr="")
+            return Mock(returncode=1, stdout="", stderr="")
+
+        mock_subprocess.side_effect = _side_effect
+
+        monkeypatch.setenv("DEV_SEC_OPS_PLATFORM", "github")
+        monkeypatch.setenv("GITHUB_PAT", "fake-token")
+
+        step = ComposeCommitsStep()
+        result = step.run(mock_context)
+
+        assert result.success is True
+        mock_post_gh.assert_not_called()
+        mock_post_glab.assert_not_called()


### PR DESCRIPTION
## Description

Extends the compose-commits workflow to post a review-context attachment comment on the open PR/MR immediately after a successful push. This mirrors the existing issue-attachment behavior but reads from the `fetch-patch` artifact instead of `fetch-issue`.

Key changes:
- Adds `load_and_render_patch_attachment` in `step_utils.py`, which loads `FetchPatchArtifact` + `PlanArtifact` and delegates to the existing `render_attachment_markdown` renderer.
- Extends `_detect_pr_platform` to return a 3-tuple `(platform, url, number)` so the PR/MR number is available for posting.
- After a successful push, `ComposeCommitsStep` calls `_post_gh_attachment_comment` (GitHub) or `_post_glab_attachment_note` (GitLab) in a best-effort block — errors are logged as warnings and never fail the step.

## Type of Change

- [x] Feature (non-breaking change which adds functionality)

## What Changed

- Added `load_and_render_patch_attachment(context)` to `step_utils.py`
- `_detect_pr_platform` now returns `(platform, url, number)` and requests `url,number` from `gh pr view`
- `ComposeCommitsStep.run` renders the patch attachment once and posts it after each successful repo push
- `TestLoadAndRenderPatchAttachment` covers all four artifact combinations
- `TestDetectPrPlatform` updated for 3-tuple return value and new gh CLI argument
- `TestPatchReviewContext` adds five integration-style scenarios for the posting logic

## How to Test

- [ ] Run `pytest tests/test_pr_attachment.py::TestLoadAndRenderPatchAttachment` — all 4 cases pass
- [ ] Run `pytest tests/test_update_pr_commits_step.py::TestDetectPrPlatform` — all cases pass with updated assertions
- [ ] Run `pytest tests/test_update_pr_commits_step.py::TestPatchReviewContext` — all 5 scenarios pass
- [ ] Trigger a compose-commits workflow run against a branch with an open PR and confirm a review-context comment is posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for posting and updating review context (source specification and implementation plan) as comments on GitHub pull requests and notes on GitLab merge requests.

* **Refactor**
  * Consolidated duplicate attachment posting logic into shared utilities to eliminate code duplication across platforms.

* **Tests**
  * Added comprehensive test coverage for patch attachment loading, rendering, and review context posting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->