### PR TITLE
feat(worker): introduce structured transition logging for issue status and worker artifact state

### DIFF
--- a/src/rouge/cli/issue.py
+++ b/src/rouge/cli/issue.py
@@ -727,8 +727,6 @@ def update(
             kwargs["branch"] = branch
         if normalized_status is not None:
             kwargs["status"] = normalized_status
-
-        # Call update_issue with the constructed kwargs
         issue = update_issue(issue_id, **kwargs)
 
         # Output issue ID on success (for scripting compatibility)

--- a/src/rouge/cli/reset.py
+++ b/src/rouge/cli/reset.py
@@ -46,7 +46,7 @@ def reset(
             raise typer.Exit(1)
 
         # Call update_issue with explicit parameters
-        # For full/thin type, clear branch; for patch type, preserve existing branch
+        # For full/thin type, clear branch; for patch/direct type, preserve existing branch
         if issue.type in ("full", "thin"):
             updated_issue = update_issue(
                 issue_id, assigned_to=None, status="pending", branch=None, adw_id=None

--- a/src/rouge/cli/resume.py
+++ b/src/rouge/cli/resume.py
@@ -127,7 +127,12 @@ def resume(
                 workflow_type=pipeline_type,
             )
         except Exception as e:
-            transition_issue_status(issue_id, "failed")
+            try:
+                transition_issue_status(issue_id, "failed")
+            except Exception as reset_err:
+                logger.warning(
+                    "Failed to reset issue %s to 'failed' after error: %s", issue_id, reset_err
+                )
             logger.exception("Workflow execution failed during resume: %s", e)
             typer.echo(
                 f"Error: Workflow execution failed during resume: {e}",
@@ -136,7 +141,14 @@ def resume(
             raise typer.Exit(1)
 
         if not success:
-            transition_issue_status(issue_id, "failed")
+            try:
+                transition_issue_status(issue_id, "failed")
+            except Exception as reset_err:
+                logger.warning(
+                    "Failed to reset issue %s to 'failed' after workflow failure: %s",
+                    issue_id,
+                    reset_err,
+                )
             typer.echo(
                 "Error: Workflow execution failed during resume",
                 err=True,

--- a/src/rouge/cli/resume.py
+++ b/src/rouge/cli/resume.py
@@ -7,7 +7,7 @@ import typer
 
 from rouge.adw.adw import execute_adw_workflow
 from rouge.cli.utils import validate_issue_id
-from rouge.core.database import fetch_issue, update_issue
+from rouge.core.database import fetch_issue, transition_issue_status
 from rouge.core.paths import RougePaths
 from rouge.core.utils import get_logger, setup_logger
 from rouge.core.workflow.artifacts import ArtifactStore, WorkflowStateArtifact
@@ -118,7 +118,7 @@ def resume(
         # Execute workflow with resume parameters
         try:
             # Reset issue status from 'failed' to 'started'
-            update_issue(issue_id, status="started")
+            transition_issue_status(issue_id, "started")
 
             success, workflow_id = execute_adw_workflow(
                 issue.adw_id,
@@ -127,7 +127,7 @@ def resume(
                 workflow_type=pipeline_type,
             )
         except Exception as e:
-            update_issue(issue_id, status="failed")
+            transition_issue_status(issue_id, "failed")
             logger.exception("Workflow execution failed during resume: %s", e)
             typer.echo(
                 f"Error: Workflow execution failed during resume: {e}",
@@ -136,7 +136,7 @@ def resume(
             raise typer.Exit(1)
 
         if not success:
-            update_issue(issue_id, status="failed")
+            transition_issue_status(issue_id, "failed")
             typer.echo(
                 "Error: Workflow execution failed during resume",
                 err=True,

--- a/src/rouge/cli/resume.py
+++ b/src/rouge/cli/resume.py
@@ -119,7 +119,6 @@ def resume(
         try:
             # Reset issue status from 'failed' to 'started'
             update_issue(issue_id, status="started")
-            logger.info("Reset issue %s status from 'failed' to 'started'", issue_id)
 
             success, workflow_id = execute_adw_workflow(
                 issue.adw_id,
@@ -161,12 +160,15 @@ def resume(
                         # Update worker to ready state
                         transition_worker_artifact(worker_artifact, "ready", clear_issue=True)
                         updated_workers.append(worker_id)
-                        logger.info("Updated worker %s to ready state", worker_id)
 
                 if updated_workers:
-                    logger.info("Updated %s worker(s) to ready state", len(updated_workers))
+                    logger.info(
+                        "Resume reset %s worker artifact(s) for issue %s",
+                        len(updated_workers),
+                        issue_id,
+                    )
                 else:
-                    logger.info("No workers found with current_issue_id=%s", issue_id)
+                    logger.debug("No workers found with current_issue_id=%s", issue_id)
         except OSError as e:
             logger.warning(
                 "Failed to scan/update worker artifacts for issue_id=%s: %s",

--- a/src/rouge/core/database.py
+++ b/src/rouge/core/database.py
@@ -600,3 +600,32 @@ def update_issue(
     except APIError as e:
         logger.exception("Database error updating issue %s", issue_id)
         raise ValueError(f"Failed to update issue {issue_id}: {e}") from e
+
+
+def transition_issue_status(
+    issue_id: int,
+    status: str,
+    **kwargs: Any,
+) -> Issue:
+    """Update issue status with standardized transition logging.
+
+    Reads the current issue to capture the from-state, delegates to
+    update_issue() for the actual update, and logs the transition at INFO.
+
+    Args:
+        issue_id: Issue ID to update
+        status: New status value
+        **kwargs: Additional fields to pass to update_issue()
+
+    Returns:
+        Updated Issue object (propagates ValueError/TypeError from update_issue)
+    """
+    current = fetch_issue(issue_id)
+    updated = update_issue(issue_id, status=status, **kwargs)
+    logger.info(
+        "Issue %s status transitioned from '%s' to '%s'",
+        issue_id,
+        current.status,
+        status,
+    )
+    return updated

--- a/src/rouge/worker/cli.py
+++ b/src/rouge/worker/cli.py
@@ -178,7 +178,7 @@ def reset_worker(
 def main_entry() -> None:
     """Entry point for the rouge-worker CLI."""
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.DEBUG,
         format="%(message)s",
         handlers=[logging.StreamHandler(sys.stdout)],
     )

--- a/src/rouge/worker/cli.py
+++ b/src/rouge/worker/cli.py
@@ -1,5 +1,6 @@
 """Command-line interface for the Rouge Worker."""
 
+import logging
 import os
 import sys
 from typing import Optional
@@ -9,6 +10,13 @@ import typer
 from .config import WorkerConfig
 from .worker import IssueWorker
 from .worker_artifact import read_worker_artifact, transition_worker_artifact
+
+# Configure logging for worker CLI commands
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
 
 
 # Compute defaults from environment
@@ -172,7 +180,6 @@ def reset_worker(
         )
         raise typer.Exit(1)
     transition_worker_artifact(artifact, "ready", clear_issue=True)
-    typer.echo(f"Worker '{worker_id}' reset to ready.")
 
 
 def main_entry() -> None:

--- a/src/rouge/worker/cli.py
+++ b/src/rouge/worker/cli.py
@@ -11,13 +11,6 @@ from .config import WorkerConfig
 from .worker import IssueWorker
 from .worker_artifact import read_worker_artifact, transition_worker_artifact
 
-# Configure logging for worker CLI commands
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(message)s",
-    handlers=[logging.StreamHandler(sys.stdout)],
-)
-
 
 # Compute defaults from environment
 def _get_default_timeout() -> int:
@@ -184,4 +177,9 @@ def reset_worker(
 
 def main_entry() -> None:
     """Entry point for the rouge-worker CLI."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
     app()

--- a/src/rouge/worker/database.py
+++ b/src/rouge/worker/database.py
@@ -7,7 +7,7 @@ import httpx
 
 from rouge.core.database import get_client as _get_client
 from rouge.core.database import reset_client
-from rouge.core.database import update_issue as _update_issue
+from rouge.core.database import transition_issue_status as _transition_issue_status
 from rouge.core.models import VALID_ISSUE_STATUSES
 from rouge.worker.exceptions import TransientDatabaseError
 
@@ -122,10 +122,7 @@ def update_issue_status(
         return False
 
     try:
-        _update_issue(issue_id, status=status)
-
-        if logger:
-            logger.debug("Updated issue %s status to %s", issue_id, status)
+        _transition_issue_status(issue_id, status)
         return True
 
     except Exception:

--- a/src/rouge/worker/database.py
+++ b/src/rouge/worker/database.py
@@ -128,4 +128,6 @@ def update_issue_status(
     except Exception:
         if logger:
             logger.exception("Error updating issue %s status", issue_id)
+        else:
+            logging.getLogger(__name__).exception("Error updating issue %s status", issue_id)
         return False

--- a/src/rouge/worker/worker_artifact.py
+++ b/src/rouge/worker/worker_artifact.py
@@ -163,12 +163,20 @@ def transition_worker_artifact(
         state: New state to set
         clear_issue: If True, clears current_issue_id and current_adw_id
     """
+    from_state = artifact.state
     artifact.state = state
     if clear_issue:
         artifact.current_issue_id = None
         artifact.current_adw_id = None
     artifact.refresh_timestamp()
     write_worker_artifact(artifact)
+    logger.info(
+        "Worker %s transitioned from '%s' to '%s'%s",
+        artifact.worker_id,
+        from_state,
+        state,
+        " (issue cleared)" if clear_issue else "",
+    )
 
 
 def write_worker_artifact(artifact: WorkerArtifact) -> None:

--- a/src/rouge/worker/worker_artifact.py
+++ b/src/rouge/worker/worker_artifact.py
@@ -169,17 +169,25 @@ def transition_worker_artifact(
         artifact.current_issue_id = None
         artifact.current_adw_id = None
     artifact.refresh_timestamp()
-    write_worker_artifact(artifact)
-    logger.info(
-        "Worker %s transitioned from '%s' to '%s'%s",
-        artifact.worker_id,
-        from_state,
-        state,
-        " (issue cleared)" if clear_issue else "",
-    )
+    wrote = write_worker_artifact(artifact)
+    if wrote:
+        logger.info(
+            "Worker %s transitioned from '%s' to '%s'%s",
+            artifact.worker_id,
+            from_state,
+            state,
+            " (issue cleared)" if clear_issue else "",
+        )
+    else:
+        logger.warning(
+            "Worker %s transition from '%s' to '%s' may not have persisted (write failed)",
+            artifact.worker_id,
+            from_state,
+            state,
+        )
 
 
-def write_worker_artifact(artifact: WorkerArtifact) -> None:
+def write_worker_artifact(artifact: WorkerArtifact) -> bool:
     """Write a worker artifact to disk.
 
     This is a best-effort operation that will not raise exceptions.
@@ -187,12 +195,15 @@ def write_worker_artifact(artifact: WorkerArtifact) -> None:
 
     Args:
         artifact: The WorkerArtifact to persist
+
+    Returns:
+        True if the artifact was successfully written, False otherwise.
     """
     try:
         artifact_path = _get_worker_artifact_path(artifact.worker_id)
     except ValueError as e:
         logger.warning("Invalid worker_id for write: %s", e)
-        return
+        return False
 
     temp_path = None
     try:
@@ -220,6 +231,7 @@ def write_worker_artifact(artifact: WorkerArtifact) -> None:
 
         # Only log success after atomic replace completes
         logger.debug("Wrote worker artifact for %s to %s", artifact.worker_id, artifact_path)
+        return True
     except Exception as e:
         # Best-effort: log but don't raise
         # Clean up temp file on failure
@@ -229,3 +241,4 @@ def write_worker_artifact(artifact: WorkerArtifact) -> None:
             except Exception:
                 pass  # Ignore cleanup errors
         logger.warning("Failed to write worker artifact for %s: %s", artifact.worker_id, e)
+        return False

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -15,6 +15,7 @@ from rouge.core.database import (
     fetch_issue,
     get_client,
     list_comments,
+    transition_issue_status,
     update_issue,
 )
 from rouge.core.models import Comment
@@ -2057,3 +2058,68 @@ def test_update_issue_adw_id_empty_raises(_mock_get_client) -> None:
     """Test validation error for empty/whitespace-only adw_id."""
     with pytest.raises(ValueError, match="adw_id cannot be empty/whitespace if provided"):
         update_issue(1, adw_id="  ")
+
+
+# ============================================================================
+# transition_issue_status tests
+# ============================================================================
+
+
+@patch("rouge.core.database.get_client")
+def test_transition_issue_status_logs_info(mock_get_client, caplog) -> None:
+    """Test that transition_issue_status emits an INFO log with issue_id, from_status, to_status."""
+    import logging
+
+    mock_client = Mock()
+    mock_table = Mock()
+
+    # Mock for fetch_issue (called by transition_issue_status)
+    mock_select_fetch = Mock()
+    mock_eq_fetch = Mock()
+    mock_execute_fetch = Mock()
+    mock_execute_fetch.data = [
+        {
+            "id": 123,
+            "description": "Test issue",
+            "status": "failed",
+        }
+    ]
+    mock_eq_fetch.execute.return_value = mock_execute_fetch
+    mock_select_fetch.eq.return_value = mock_eq_fetch
+
+    # Mock for update_issue select check
+    mock_select_check = Mock()
+    mock_eq_check = Mock()
+    mock_execute_check = Mock()
+    mock_execute_check.data = [{"id": 123}]
+    mock_eq_check.execute.return_value = mock_execute_check
+    mock_select_check.eq.return_value = mock_eq_check
+
+    # Mock for update_issue update call
+    mock_update = Mock()
+    mock_eq_update = Mock()
+    mock_execute_update = Mock()
+    mock_execute_update.data = [
+        {
+            "id": 123,
+            "description": "Test issue",
+            "status": "pending",
+        }
+    ]
+    mock_eq_update.execute.return_value = mock_execute_update
+    mock_update.eq.return_value = mock_eq_update
+
+    # Chain the table mock to return the right sub-mocks in order:
+    # 1st call: fetch_issue -> select("*").eq("id", 123)
+    # 2nd call: update_issue -> select("id").eq("id", 123)  (existence check)
+    # 3rd call: update_issue -> update({...}).eq("id", 123)
+    mock_table.select.side_effect = [mock_select_fetch, mock_select_check]
+    mock_table.update.return_value = mock_update
+    mock_client.table.return_value = mock_table
+    mock_get_client.return_value = mock_client
+
+    with caplog.at_level(logging.INFO):
+        result = transition_issue_status(123, "pending", assigned_to=None)
+
+    assert result.id == 123
+    assert "Issue 123 status transitioned from 'failed' to 'pending'" in caplog.text

--- a/tests/test_integration_resume.py
+++ b/tests/test_integration_resume.py
@@ -168,7 +168,7 @@ class TestEndToEndResumeFlow:
                 write_worker_artifact(worker)
 
                 with patch("rouge.cli.resume.fetch_issue", return_value=mock_issue):
-                    with patch("rouge.cli.resume.update_issue") as mock_update:
+                    with patch("rouge.cli.resume.transition_issue_status") as mock_update:
                         with patch("rouge.cli.resume.execute_adw_workflow") as mock_execute:
                             mock_execute.return_value = (True, "adw-resume-123")
 
@@ -183,7 +183,7 @@ class TestEndToEndResumeFlow:
                 assert "adw-resume-123" in result.output
 
                 # Verify issue status was updated to started
-                mock_update.assert_called_once_with(123, status="started")
+                mock_update.assert_called_once_with(123, "started")
 
                 # Verify execute_adw_workflow was called with correct params
                 mock_execute.assert_called_once_with(
@@ -484,7 +484,7 @@ class TestWorkerArtifactResumeIntegration:
 
             with patch("rouge.cli.resume.RougePaths.get_base_dir", return_value=tmp_path):
                 with patch("rouge.cli.resume.fetch_issue", return_value=mock_issue):
-                    with patch("rouge.cli.resume.update_issue"):
+                    with patch("rouge.cli.resume.transition_issue_status"):
                         with patch("rouge.cli.resume.execute_adw_workflow") as mock_execute:
                             mock_execute.return_value = (True, "adw-789")
 

--- a/tests/test_resume_command.py
+++ b/tests/test_resume_command.py
@@ -139,10 +139,10 @@ class TestResumeCommandArtifactLoading:
     """Tests for workflow state artifact loading in resume command."""
 
     @patch("rouge.cli.resume.execute_adw_workflow")
-    @patch("rouge.cli.resume.update_issue")
+    @patch("rouge.cli.resume.transition_issue_status")
     @patch("rouge.cli.resume.fetch_issue")
     def test_resume_loads_workflow_state_artifact(
-        self, mock_fetch_issue, mock_update_issue, mock_execute_adw, tmp_path
+        self, mock_fetch_issue, mock_transition_issue_status, mock_execute_adw, tmp_path
     ) -> None:
         """Test resume command loads workflow state artifact."""
         mock_issue = Issue(
@@ -256,10 +256,10 @@ class TestResumeCommandWorkflowInvocation:
     """Tests for workflow execution during resume."""
 
     @patch("rouge.cli.resume.execute_adw_workflow")
-    @patch("rouge.cli.resume.update_issue")
+    @patch("rouge.cli.resume.transition_issue_status")
     @patch("rouge.cli.resume.fetch_issue")
     def test_resume_invokes_execute_adw_workflow(
-        self, mock_fetch_issue, mock_update_issue, mock_execute_adw, tmp_path
+        self, mock_fetch_issue, mock_transition_issue_status, mock_execute_adw, tmp_path
     ) -> None:
         """Test resume command invokes execute_adw_workflow with correct params."""
         mock_issue = Issue(
@@ -295,10 +295,10 @@ class TestResumeCommandWorkflowInvocation:
             )
 
     @patch("rouge.cli.resume.execute_adw_workflow")
-    @patch("rouge.cli.resume.update_issue")
+    @patch("rouge.cli.resume.transition_issue_status")
     @patch("rouge.cli.resume.fetch_issue")
     def test_resume_resets_issue_status_to_started(
-        self, mock_fetch_issue, mock_update_issue, mock_execute_adw, tmp_path
+        self, mock_fetch_issue, mock_transition_issue_status, mock_execute_adw, tmp_path
     ) -> None:
         """Test resume command resets issue status from failed to started."""
         mock_issue = Issue(
@@ -326,13 +326,13 @@ class TestResumeCommandWorkflowInvocation:
             result = runner.invoke(app, ["resume", "888"])
 
             assert result.exit_code == 0
-            mock_update_issue.assert_called_once_with(888, status="started")
+            mock_transition_issue_status.assert_called_once_with(888, "started")
 
     @patch("rouge.cli.resume.execute_adw_workflow")
-    @patch("rouge.cli.resume.update_issue")
+    @patch("rouge.cli.resume.transition_issue_status")
     @patch("rouge.cli.resume.fetch_issue")
     def test_resume_fails_when_workflow_execution_fails(
-        self, mock_fetch_issue, mock_update_issue, mock_execute_adw, tmp_path
+        self, mock_fetch_issue, mock_transition_issue_status, mock_execute_adw, tmp_path
     ) -> None:
         """Test resume command handles workflow execution failure."""
         mock_issue = Issue(
@@ -363,10 +363,10 @@ class TestResumeCommandWorkflowInvocation:
             assert "Error: Workflow execution failed during resume" in result.output
 
     @patch("rouge.cli.resume.execute_adw_workflow")
-    @patch("rouge.cli.resume.update_issue")
+    @patch("rouge.cli.resume.transition_issue_status")
     @patch("rouge.cli.resume.fetch_issue")
     def test_resume_outputs_workflow_id_on_success(
-        self, mock_fetch_issue, mock_update_issue, mock_execute_adw, tmp_path
+        self, mock_fetch_issue, mock_transition_issue_status, mock_execute_adw, tmp_path
     ) -> None:
         """Test resume command outputs workflow ID on success."""
         mock_issue = Issue(
@@ -403,14 +403,14 @@ class TestResumeCommandWorkerArtifactUpdate:
     @patch("rouge.cli.resume.transition_worker_artifact")
     @patch("rouge.cli.resume.read_worker_artifact")
     @patch("rouge.cli.resume.execute_adw_workflow")
-    @patch("rouge.cli.resume.update_issue")
+    @patch("rouge.cli.resume.transition_issue_status")
     @patch("rouge.cli.resume.fetch_issue")
     @patch("rouge.cli.resume.RougePaths.get_base_dir")
     def test_resume_updates_worker_with_matching_issue_id(
         self,
         mock_get_base_dir,
         mock_fetch_issue,
-        mock_update_issue,
+        mock_transition_issue_status,
         mock_execute_adw,
         mock_read_worker,
         mock_transition_worker,
@@ -481,14 +481,14 @@ class TestResumeCommandWorkerArtifactUpdate:
     @patch("rouge.cli.resume.transition_worker_artifact")
     @patch("rouge.cli.resume.read_worker_artifact")
     @patch("rouge.cli.resume.execute_adw_workflow")
-    @patch("rouge.cli.resume.update_issue")
+    @patch("rouge.cli.resume.transition_issue_status")
     @patch("rouge.cli.resume.fetch_issue")
     @patch("rouge.cli.resume.RougePaths.get_base_dir")
     def test_resume_skips_workers_without_matching_issue_id(
         self,
         mock_get_base_dir,
         mock_fetch_issue,
-        mock_update_issue,
+        mock_transition_issue_status,
         mock_execute_adw,
         mock_read_worker,
         mock_transition_worker,
@@ -540,11 +540,16 @@ class TestResumeCommandWorkerArtifactUpdate:
             mock_transition_worker.assert_not_called()
 
     @patch("rouge.cli.resume.execute_adw_workflow")
-    @patch("rouge.cli.resume.update_issue")
+    @patch("rouge.cli.resume.transition_issue_status")
     @patch("rouge.cli.resume.fetch_issue")
     @patch("rouge.cli.resume.RougePaths.get_base_dir")
     def test_resume_handles_missing_workers_directory(
-        self, mock_get_base_dir, mock_fetch_issue, mock_update_issue, mock_execute_adw, tmp_path
+        self,
+        mock_get_base_dir,
+        mock_fetch_issue,
+        mock_transition_issue_status,
+        mock_execute_adw,
+        tmp_path,
     ) -> None:
         """Test resume handles case when workers directory doesn't exist."""
         # No workers directory created
@@ -582,10 +587,10 @@ class TestResumeCommandResumeFromOverride:
     """Tests for --resume-from CLI option override behavior."""
 
     @patch("rouge.cli.resume.execute_adw_workflow")
-    @patch("rouge.cli.resume.update_issue")
+    @patch("rouge.cli.resume.transition_issue_status")
     @patch("rouge.cli.resume.fetch_issue")
     def test_resume_from_with_no_failed_step_succeeds(
-        self, mock_fetch_issue, mock_update_issue, mock_execute_adw, tmp_path
+        self, mock_fetch_issue, mock_transition_issue_status, mock_execute_adw, tmp_path
     ) -> None:
         """Test --resume-from provided with failed_step=None succeeds and uses supplied step."""
         mock_issue = Issue(
@@ -622,10 +627,10 @@ class TestResumeCommandResumeFromOverride:
             )
 
     @patch("rouge.cli.resume.execute_adw_workflow")
-    @patch("rouge.cli.resume.update_issue")
+    @patch("rouge.cli.resume.transition_issue_status")
     @patch("rouge.cli.resume.fetch_issue")
     def test_resume_from_overrides_failed_step(
-        self, mock_fetch_issue, mock_update_issue, mock_execute_adw, tmp_path
+        self, mock_fetch_issue, mock_transition_issue_status, mock_execute_adw, tmp_path
     ) -> None:
         """Test --resume-from wins over failed_step when both are set."""
         mock_issue = Issue(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -348,9 +348,11 @@ class TestUpdateIssueStatus:
         mock_issue.id = 123
         mock_issue.status = "completed"
 
-        with patch("rouge.worker.database._update_issue", return_value=mock_issue) as mock_update:
+        with patch(
+            "rouge.worker.database._transition_issue_status", return_value=mock_issue
+        ) as mock_transition:
             database.update_issue_status(123, "completed")
-            mock_update.assert_called_once_with(123, status="completed")
+            mock_transition.assert_called_once_with(123, "completed")
 
     def test_update_issue_status_claimed_accepted(self, mock_env) -> None:
         """Test that 'claimed' is accepted as a valid status by update_issue_status."""
@@ -358,13 +360,18 @@ class TestUpdateIssueStatus:
         mock_issue.id = 123
         mock_issue.status = "claimed"
 
-        with patch("rouge.worker.database._update_issue", return_value=mock_issue) as mock_update:
+        with patch(
+            "rouge.worker.database._transition_issue_status", return_value=mock_issue
+        ) as mock_transition:
             database.update_issue_status(123, "claimed")
-            mock_update.assert_called_once_with(123, status="claimed")
+            mock_transition.assert_called_once_with(123, "claimed")
 
     def test_update_issue_status_database_error(self, mock_env) -> None:
         """Test handling database errors during status update."""
-        with patch("rouge.worker.database._update_issue", side_effect=Exception("Database error")):
+        with patch(
+            "rouge.worker.database._transition_issue_status",
+            side_effect=Exception("Database error"),
+        ):
             # Should not raise exception
             database.update_issue_status(123, "completed")
 
@@ -1519,7 +1526,7 @@ class TestWorkerResetCLI:
         ):
             result = runner.invoke(worker_app, ["reset", "test-worker"])
         assert result.exit_code == 0
-        assert "reset to ready" in result.output
+        # Step 4 removed typer.echo; transition is now logged via transition_worker_artifact
         mock_transition.assert_called_once_with(failed_artifact, "ready", clear_issue=True)
 
     def test_worker_reset_succeeds_when_working(self) -> None:
@@ -1538,5 +1545,5 @@ class TestWorkerResetCLI:
         ):
             result = runner.invoke(worker_app, ["reset", "test-worker"])
         assert result.exit_code == 0
-        assert "reset to ready" in result.output
+        # Step 4 removed typer.echo; transition is now logged via transition_worker_artifact
         mock_transition.assert_called_once_with(working_artifact, "ready", clear_issue=True)

--- a/tests/test_worker_artifact.py
+++ b/tests/test_worker_artifact.py
@@ -1,6 +1,7 @@
 """Unit tests for WorkerArtifact and worker artifact persistence."""
 
 import json
+import logging
 from datetime import datetime
 from unittest.mock import patch
 
@@ -10,6 +11,7 @@ from pydantic import ValidationError
 from rouge.worker.worker_artifact import (
     WorkerArtifact,
     read_worker_artifact,
+    transition_worker_artifact,
     write_worker_artifact,
 )
 
@@ -456,3 +458,38 @@ class TestWorkerArtifactPath:
         assert path1.parent != path2.parent
         assert path1.parent.name == "worker-1"
         assert path2.parent.name == "worker-2"
+
+
+class TestTransitionWorkerArtifactLogging:
+    """Tests for transition_worker_artifact INFO logging."""
+
+    @patch("rouge.worker.worker_artifact.write_worker_artifact")
+    def test_transition_worker_artifact_logs_info(self, _mock_write, caplog):
+        """Test that transition_worker_artifact emits an INFO log with expected format."""
+        artifact = WorkerArtifact(worker_id="w1", state="working")
+        with caplog.at_level(logging.INFO):
+            transition_worker_artifact(artifact, "ready", clear_issue=True)
+        assert "Worker w1 transitioned from 'working' to 'ready' (issue cleared)" in caplog.text
+
+    @patch("rouge.worker.worker_artifact.write_worker_artifact")
+    def test_transition_worker_artifact_logs_without_clear_issue(self, _mock_write, caplog):
+        """Test log message omits '(issue cleared)' when clear_issue is False."""
+        artifact = WorkerArtifact(worker_id="w2", state="ready")
+        with caplog.at_level(logging.INFO):
+            transition_worker_artifact(artifact, "working")
+        assert "Worker w2 transitioned from 'ready' to 'working'" in caplog.text
+        assert "(issue cleared)" not in caplog.text
+
+    @patch("rouge.worker.worker_artifact.write_worker_artifact")
+    def test_transition_worker_artifact_updates_state(self, _mock_write):
+        """Test that transition_worker_artifact actually updates the artifact state."""
+        artifact = WorkerArtifact(
+            worker_id="w3",
+            state="working",
+            current_issue_id=42,
+            current_adw_id="adw-42",
+        )
+        transition_worker_artifact(artifact, "ready", clear_issue=True)
+        assert artifact.state == "ready"
+        assert artifact.current_issue_id is None
+        assert artifact.current_adw_id is None

--- a/tests/test_worker_artifact.py
+++ b/tests/test_worker_artifact.py
@@ -464,7 +464,7 @@ class TestTransitionWorkerArtifactLogging:
     """Tests for transition_worker_artifact INFO logging."""
 
     @patch("rouge.worker.worker_artifact.write_worker_artifact")
-    def test_transition_worker_artifact_logs_info(self, _mock_write, caplog):
+    def test_transition_worker_artifact_logs_info(self, _mock_write, caplog) -> None:
         """Test that transition_worker_artifact emits an INFO log with expected format."""
         artifact = WorkerArtifact(worker_id="w1", state="working")
         with caplog.at_level(logging.INFO):
@@ -472,7 +472,7 @@ class TestTransitionWorkerArtifactLogging:
         assert "Worker w1 transitioned from 'working' to 'ready' (issue cleared)" in caplog.text
 
     @patch("rouge.worker.worker_artifact.write_worker_artifact")
-    def test_transition_worker_artifact_logs_without_clear_issue(self, _mock_write, caplog):
+    def test_transition_worker_artifact_logs_without_clear_issue(self, _mock_write, caplog) -> None:
         """Test log message omits '(issue cleared)' when clear_issue is False."""
         artifact = WorkerArtifact(worker_id="w2", state="ready")
         with caplog.at_level(logging.INFO):
@@ -481,7 +481,7 @@ class TestTransitionWorkerArtifactLogging:
         assert "(issue cleared)" not in caplog.text
 
     @patch("rouge.worker.worker_artifact.write_worker_artifact")
-    def test_transition_worker_artifact_updates_state(self, _mock_write):
+    def test_transition_worker_artifact_updates_state(self, _mock_write) -> None:
         """Test that transition_worker_artifact actually updates the artifact state."""
         artifact = WorkerArtifact(
             worker_id="w3",


### PR DESCRIPTION
## Description

Introduces `transition_issue_status()` in `core/database` as a single canonical helper for issue status changes that captures the from/to state and emits a structured INFO log. Wires this helper and complementary logging into the worker stack (`worker/database`, `worker/worker_artifact`, `worker/cli`, `cli/resume`) so all state transitions produce consistent, auditable log output without relying on scattered `typer.echo` or ad-hoc logger calls.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Added `transition_issue_status()` to `core/database` — reads current issue, calls `update_issue()`, and logs `"Issue N status transitioned from 'X' to 'Y'"` at INFO
- `worker/database`: replaced direct `_update_issue` call with `_transition_issue_status` so every status update goes through the logging helper
- `worker/worker_artifact`: captures `from_state` before mutation in `transition_worker_artifact()` and emits a structured INFO log with optional `(issue cleared)` suffix
- `worker/cli`: added `logging.basicConfig` so worker CLI commands surface log output to stdout; removed `typer.echo` from `reset_worker` (transition log covers it)
- `cli/resume`: consolidated worker-count INFO log and downgraded no-workers-found to DEBUG
- `cli/issue` and `cli/reset`: removed redundant/outdated inline comments
- Tests: added `test_transition_issue_status_logs_info`, updated worker database mocks to `_transition_issue_status`, and added `TestTransitionWorkerArtifactLogging` with three cases

## How to Test

- [ ] Run `pytest tests/test_database.py -k transition_issue_status` — should pass
- [ ] Run `pytest tests/test_worker.py -k TestUpdateIssueStatus` — should pass
- [ ] Run `pytest tests/test_worker_artifact.py -k TestTransitionWorkerArtifactLogging` — should pass
- [ ] Run `rouge worker reset <worker-id>` on a failed/working worker and confirm the transition log line appears in stdout (no bare echo)
- [ ] Run a workflow that triggers issue status updates and confirm `Issue N status transitioned from 'X' to 'Y'` appears in worker logs