### PR TITLE
Fix rouge mr repo display

### DIFF
--- a/src/rouge/cli/mr.py
+++ b/src/rouge/cli/mr.py
@@ -122,21 +122,32 @@ def list_command(
         if format == OutputFormat.JSON:
             typer.echo(json.dumps(results, indent=2))
         else:
-            header = (
-                f"{'Issue':<8} {'Platform':<10} {'Repo':<30}"
-                f" {'Number':<8} {'URL':<50} {'Adopted':<8}"
-            )
-            typer.echo(header)
-            typer.echo("-" * 116)
-
+            rows = []
             for row in results:
-                issue = str(row.get("issue_id", ""))
-                plat = row.get("platform") or "(none)"
-                repo = row.get("repo") or "(none)"
-                number = str(row.get("number", ""))
-                url = row.get("url") or "(none)"
-                adopted = str(row.get("adopted", False))
-                typer.echo(f"{issue:<8} {plat:<10} {repo:<30} {number:<8} {url:<50} {adopted:<8}")
+                rows.append(
+                    {
+                        "Issue": str(row.get("issue_id", "")),
+                        "Platform": row.get("platform") or "(none)",
+                        "Repo": row.get("repo") or "(none)",
+                        "Number": str(row.get("number", "")),
+                        "URL": row.get("url") or "(none)",
+                        "Adopted": str(row.get("adopted", False)),
+                    }
+                )
+
+            columns = ["Issue", "Platform", "Repo", "Number", "URL", "Adopted"]
+            widths = {
+                column: max(len(column), *(len(row[column]) for row in rows)) for column in columns
+            }
+
+            def format_row(row: dict[str, str]) -> str:
+                return "  ".join(f"{row[column]:<{widths[column]}}" for column in columns).rstrip()
+
+            header = format_row({column: column for column in columns})
+            typer.echo(header)
+            typer.echo("-" * len(header))
+            for row in rows:
+                typer.echo(format_row(row))
 
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)

--- a/src/rouge/core/database.py
+++ b/src/rouge/core/database.py
@@ -6,7 +6,6 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Optional
-from urllib.parse import urlparse
 
 import httpx
 from dotenv import find_dotenv, load_dotenv
@@ -14,7 +13,7 @@ from postgrest.exceptions import APIError
 from supabase import Client, ClientOptions, create_client
 
 from rouge.core.models import VALID_ISSUE_STATUSES, Comment, Issue
-from rouge.core.utils import make_adw_id
+from rouge.core.utils import extract_repo_from_pull_request_url, make_adw_id
 
 logger = logging.getLogger(__name__)
 
@@ -469,7 +468,7 @@ def list_mr_comments(
                     continue
                 repo = pr_entry.get("repo")
                 if not isinstance(repo, str) or "/" not in repo:
-                    repo = _extract_repo_from_pull_request_url(pr_entry.get("url")) or repo
+                    repo = extract_repo_from_pull_request_url(pr_entry.get("url")) or repo
                 results.append(
                     {
                         "issue_id": row.get("issue_id"),
@@ -487,30 +486,6 @@ def list_mr_comments(
     except APIError as e:
         logger.exception("Database error listing MR comments")
         raise ValueError(f"Failed to list MR comments: {e}") from e
-
-
-def _extract_repo_from_pull_request_url(url: Any) -> str | None:
-    """Extract owner/repo (or group/project) from a PR/MR URL."""
-    if not isinstance(url, str) or not url:
-        return None
-
-    parsed = urlparse(url)
-    path_parts = [part for part in parsed.path.split("/") if part]
-    if not path_parts:
-        return None
-
-    if "pull" in path_parts:
-        marker_index = path_parts.index("pull")
-        repo_parts = path_parts[:marker_index]
-    elif "-" in path_parts:
-        marker_index = path_parts.index("-")
-        repo_parts = path_parts[:marker_index]
-    else:
-        repo_parts = path_parts[:2]
-
-    if len(repo_parts) < 2:
-        return None
-    return "/".join(repo_parts)
 
 
 # ============================================================================

--- a/src/rouge/core/database.py
+++ b/src/rouge/core/database.py
@@ -6,6 +6,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 import httpx
 from dotenv import find_dotenv, load_dotenv
@@ -466,12 +467,15 @@ def list_mr_comments(
                         row.get("id"),
                     )
                     continue
+                repo = pr_entry.get("repo")
+                if not isinstance(repo, str) or "/" not in repo:
+                    repo = _extract_repo_from_pull_request_url(pr_entry.get("url")) or repo
                 results.append(
                     {
                         "issue_id": row.get("issue_id"),
                         "adw_id": row.get("adw_id"),
                         "platform": artifact_platform,
-                        "repo": pr_entry.get("repo"),
+                        "repo": repo,
                         "number": pr_entry.get("number"),
                         "url": pr_entry.get("url"),
                         "adopted": pr_entry.get("adopted", False),
@@ -483,6 +487,30 @@ def list_mr_comments(
     except APIError as e:
         logger.exception("Database error listing MR comments")
         raise ValueError(f"Failed to list MR comments: {e}") from e
+
+
+def _extract_repo_from_pull_request_url(url: Any) -> str | None:
+    """Extract owner/repo (or group/project) from a PR/MR URL."""
+    if not isinstance(url, str) or not url:
+        return None
+
+    parsed = urlparse(url)
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if not path_parts:
+        return None
+
+    if "pull" in path_parts:
+        marker_index = path_parts.index("pull")
+        repo_parts = path_parts[:marker_index]
+    elif "-" in path_parts:
+        marker_index = path_parts.index("-")
+        repo_parts = path_parts[:marker_index]
+    else:
+        repo_parts = path_parts[:2]
+
+    if len(repo_parts) < 2:
+        return None
+    return "/".join(repo_parts)
 
 
 # ============================================================================

--- a/src/rouge/core/utils.py
+++ b/src/rouge/core/utils.py
@@ -5,6 +5,8 @@ import os
 import sys
 import uuid
 from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
 
 
 def make_adw_id() -> str:
@@ -121,3 +123,27 @@ def get_logger(adw_id: str) -> logging.Logger:
     if not adw_id:
         raise ValueError("adw_id must be a non-empty string")
     return logging.getLogger(f"rouge_{adw_id}")
+
+
+def extract_repo_from_pull_request_url(url: Any) -> str | None:
+    """Extract owner/repo (or group/project) from a PR/MR URL."""
+    if not isinstance(url, str) or not url:
+        return None
+
+    parsed = urlparse(url)
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if not path_parts:
+        return None
+
+    if "pull" in path_parts:
+        marker_index = path_parts.index("pull")
+        repo_parts = path_parts[:marker_index]
+    elif "-" in path_parts:
+        marker_index = path_parts.index("-")
+        repo_parts = path_parts[:marker_index]
+    else:
+        repo_parts = path_parts[:2]
+
+    if len(repo_parts) < 2:
+        return None
+    return "/".join(repo_parts)

--- a/src/rouge/core/workflow/pull_request_step_base.py
+++ b/src/rouge/core/workflow/pull_request_step_base.py
@@ -8,13 +8,12 @@ import os
 import subprocess
 from abc import ABC, abstractmethod
 from typing import ClassVar
-from urllib.parse import urlparse
 
 from rouge.core.notifications.comments import (
     emit_artifact_comment,
     log_artifact_comment_status,
 )
-from rouge.core.utils import get_logger
+from rouge.core.utils import extract_repo_from_pull_request_url, get_logger
 from rouge.core.workflow.artifacts import (
     ArtifactType,
     ComposeRequestArtifact,
@@ -25,30 +24,6 @@ from rouge.core.workflow.shared import get_affected_repo_paths, has_branch_delta
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
 from rouge.core.workflow.step_utils import _emit_and_log, load_and_render_attachment
 from rouge.core.workflow.types import StepResult
-
-
-def _extract_repo_from_pull_request_url(url: str | None) -> str | None:
-    """Extract owner/repo or group/project from a pull/merge request URL."""
-    if not url:
-        return None
-
-    parsed = urlparse(url)
-    path_parts = [part for part in parsed.path.split("/") if part]
-    if not path_parts:
-        return None
-
-    if "pull" in path_parts:
-        marker_index = path_parts.index("pull")
-        repo_parts = path_parts[:marker_index]
-    elif "-" in path_parts:
-        marker_index = path_parts.index("-")
-        repo_parts = path_parts[:marker_index]
-    else:
-        repo_parts = path_parts[:2]
-
-    if len(repo_parts) < 2:
-        return None
-    return "/".join(repo_parts)
 
 
 class PullRequestStepBase(WorkflowStep, ABC):
@@ -232,7 +207,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
                     item_url, item_number = self._parse_existing_item(existing_item)
                     if item_url:
                         repo_display_name = (
-                            _extract_repo_from_pull_request_url(item_url) or repo_name
+                            extract_repo_from_pull_request_url(item_url) or repo_name
                         )
                         logger.info(
                             "Adopting existing %s for repo %s: %s",
@@ -449,7 +424,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
             return
 
         item_url, item_number = parsed
-        repo_display_name = _extract_repo_from_pull_request_url(item_url) or repo_name
+        repo_display_name = extract_repo_from_pull_request_url(item_url) or repo_name
         logger.info("%s created for %s: %s", self.entity_name, repo_display_name, item_url)
 
         entry = PullRequestEntry(

--- a/src/rouge/core/workflow/pull_request_step_base.py
+++ b/src/rouge/core/workflow/pull_request_step_base.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 from abc import ABC, abstractmethod
 from typing import ClassVar
+from urllib.parse import urlparse
 
 from rouge.core.notifications.comments import (
     emit_artifact_comment,
@@ -24,6 +25,30 @@ from rouge.core.workflow.shared import get_affected_repo_paths, has_branch_delta
 from rouge.core.workflow.step_base import WorkflowContext, WorkflowStep
 from rouge.core.workflow.step_utils import _emit_and_log, load_and_render_attachment
 from rouge.core.workflow.types import StepResult
+
+
+def _extract_repo_from_pull_request_url(url: str | None) -> str | None:
+    """Extract owner/repo or group/project from a pull/merge request URL."""
+    if not url:
+        return None
+
+    parsed = urlparse(url)
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if not path_parts:
+        return None
+
+    if "pull" in path_parts:
+        marker_index = path_parts.index("pull")
+        repo_parts = path_parts[:marker_index]
+    elif "-" in path_parts:
+        marker_index = path_parts.index("-")
+        repo_parts = path_parts[:marker_index]
+    else:
+        repo_parts = path_parts[:2]
+
+    if len(repo_parts) < 2:
+        return None
+    return "/".join(repo_parts)
 
 
 class PullRequestStepBase(WorkflowStep, ABC):
@@ -206,14 +231,17 @@ class PullRequestStepBase(WorkflowStep, ABC):
                     existing_item = item_list[0]
                     item_url, item_number = self._parse_existing_item(existing_item)
                     if item_url:
+                        repo_display_name = (
+                            _extract_repo_from_pull_request_url(item_url) or repo_name
+                        )
                         logger.info(
                             "Adopting existing %s for repo %s: %s",
                             self.entity_name,
-                            repo_name,
+                            repo_display_name,
                             item_url,
                         )
                         entry = PullRequestEntry(
-                            repo=repo_name,
+                            repo=repo_display_name,
                             repo_path=repo_path,
                             url=item_url,
                             number=item_number,
@@ -421,10 +449,11 @@ class PullRequestStepBase(WorkflowStep, ABC):
             return
 
         item_url, item_number = parsed
-        logger.info("%s created for %s: %s", self.entity_name, repo_name, item_url)
+        repo_display_name = _extract_repo_from_pull_request_url(item_url) or repo_name
+        logger.info("%s created for %s: %s", self.entity_name, repo_display_name, item_url)
 
         entry = PullRequestEntry(
-            repo=repo_name,
+            repo=repo_display_name,
             repo_path=repo_path,
             url=item_url,
             number=item_number,

--- a/tests/test_cli_mr.py
+++ b/tests/test_cli_mr.py
@@ -47,6 +47,7 @@ class TestMrListCommand:
         assert "123" in result.output
         assert "https://github.com/org/repo/pull/123" in result.output
         assert "False" in result.output
+        assert "org/repo                       " not in result.output
 
     @patch("rouge.cli.mr.list_mr_comments")
     def test_list_json_output(self, mock_list_mr_comments) -> None:

--- a/tests/test_database_mr.py
+++ b/tests/test_database_mr.py
@@ -225,6 +225,30 @@ class TestListMrComments:
         assert results == []
 
     @patch("rouge.core.database.get_client")
+    def test_repo_falls_back_to_url_owner_and_repo(self, mock_get_client: Mock) -> None:
+        """Repo display uses owner/repo from URL when stored repo is only a basename."""
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+
+        rows = [
+            _make_comment_row(
+                pull_requests=[
+                    {
+                        "repo": "rouge",
+                        "number": 123,
+                        "url": "https://github.com/bponghneng/rouge/pull/123",
+                        "adopted": False,
+                    }
+                ]
+            )
+        ]
+        _build_mock_chain(mock_client, rows)
+
+        results = list_mr_comments()
+
+        assert results[0]["repo"] == "bponghneng/rouge"
+
+    @patch("rouge.core.database.get_client")
     def test_malformed_payload_missing_pull_requests(self, mock_get_client: Mock) -> None:
         """Comment with raw missing artifact.pull_requests is skipped."""
         mock_client = Mock()

--- a/tests/test_gh_pull_request_step.py
+++ b/tests/test_gh_pull_request_step.py
@@ -165,6 +165,53 @@ class TestGhPullRequestStepWithArtifact:
         # Step should succeed (either skip due to missing gh or GITHUB_PAT)
         assert result.success is True
 
+    @patch("rouge.core.workflow.pull_request_step_base._emit_and_log")
+    @patch("rouge.core.workflow.pull_request_step_base.emit_artifact_comment")
+    @patch("rouge.core.workflow.pull_request_step_base.log_artifact_comment_status")
+    @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
+    @patch("rouge.core.workflow.pull_request_step_base.subprocess.run")
+    @patch("rouge.core.workflow.pull_request_step_base.os.environ", new_callable=dict)
+    def test_stores_full_github_repo_name_in_artifact(
+        self,
+        mock_environ,
+        mock_run,
+        mock_which,
+        _mock_log,
+        mock_emit_artifact,
+        mock_emit,
+        store: ArtifactStore,
+    ) -> None:
+        """Stored PR artifact uses owner/repo rather than only the repo basename."""
+        mock_environ["GITHUB_PAT"] = "fake-token"
+        mock_environ["PATH"] = "/usr/bin"
+        mock_which.return_value = "/usr/bin/gh"
+        mock_emit_artifact.return_value = ("success", "ok")
+        mock_run.side_effect = _gh_subprocess_side_effect
+
+        store.write_artifact(
+            ComposeRequestArtifact(
+                workflow_id="test-gh-pr",
+                title="My PR Title",
+                summary="My PR Summary",
+                commits=[],
+            )
+        )
+
+        context = WorkflowContext(
+            adw_id="test-gh-pr",
+            issue_id=42,
+            artifact_store=store,
+            repo_paths=["/path/to/repo"],
+            pipeline_type="full",
+        )
+
+        step = GhPullRequestStep()
+        result = step.run(context)
+
+        assert result.success is True
+        artifact = store.read_artifact("gh-pull-request")
+        assert artifact.pull_requests[0].repo == "org/repo"
+
 
 class TestGhPullRequestStepDraftFlag:
     """Tests verifying GhPullRequestStep adds --draft flag based on pipeline_type."""

--- a/tests/test_glab_pull_request_step.py
+++ b/tests/test_glab_pull_request_step.py
@@ -447,6 +447,34 @@ class TestGlabPullRequestStepDraftFlag:
     @patch("rouge.core.workflow.pull_request_step_base.log_artifact_comment_status")
     @patch("rouge.core.workflow.pull_request_step_base.subprocess.run")
     @patch("rouge.core.workflow.pull_request_step_base.os.environ", new_callable=dict)
+    def test_stores_full_gitlab_repo_name_in_artifact(
+        self,
+        mock_environ,
+        mock_run,
+        _mock_log,
+        mock_emit_artifact,
+        mock_emit_and_log,
+        store_mr: ArtifactStore,
+    ) -> None:
+        """Stored MR artifact uses group/project rather than only the repo basename."""
+        mock_environ["GITLAB_PAT"] = "fake-token"
+        mock_emit_artifact.return_value = ("success", "ok")
+        mock_run.side_effect = _subprocess_side_effect
+
+        context = _make_context(store_mr, pipeline_type="full")
+
+        step = GlabPullRequestStep()
+        result = step.run(context)
+
+        assert result.success is True
+        artifact = store_mr.read_artifact("glab-pull-request")
+        assert artifact.pull_requests[0].repo == "org/repo"
+
+    @patch("rouge.core.workflow.pull_request_step_base._emit_and_log")
+    @patch("rouge.core.workflow.pull_request_step_base.emit_artifact_comment")
+    @patch("rouge.core.workflow.pull_request_step_base.log_artifact_comment_status")
+    @patch("rouge.core.workflow.pull_request_step_base.subprocess.run")
+    @patch("rouge.core.workflow.pull_request_step_base.os.environ", new_callable=dict)
     def test_patch_pipeline_omits_draft_flag(
         self,
         mock_environ,


### PR DESCRIPTION
## Description
- tighten rouge mr table formatting so the repo column does not use excessive fixed padding
- show full owner/repo identifiers in rouge mr list, including fallback normalization for older artifact rows
- store full repo identifiers in new PR/MR artifacts and add regression coverage

## How to Test
- uv run ruff check src/
- uv run mypy
- uv run pytest tests/ -v

## Artifacts
- Conversation: https://app.warp.dev/conversation/26b91ebe-6f36-44f7-8028-d5eb711ddce1

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved merge request table output with dynamic column formatting for better readability.
  * Repository information in pull/merge request artifacts now displays full names (e.g., `owner/repo` format) instead of partial identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->