### PR TITLE
docs(env): document global vs per-workspace configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,10 @@
 
 # === Platform (required) ======================================================
 # Supabase project URL.
-SUPABASE_URL=https://your-project.supabase.co
+# SUPABASE_URL=https://your-project.supabase.co
 
 # Supabase service role key.
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # === Platform (optional) ======================================================
 # Supabase HTTP timeout in seconds (default: 30).
@@ -45,7 +45,7 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # === Git Platform Integration (optional) ======================================
 # DevSecOps platform for PR/MR steps. If unset, PR/MR creation is skipped.
 # Options: "github", "gitlab"
-# DEV_SEC_OPS_PLATFORM=github
+DEV_SEC_OPS_PLATFORM=github
 
 # GitHub PAT for PR creation; also exported as GH_TOKEN for agent subprocesses.
 # Requires `gh` CLI and repo access scope.
@@ -67,7 +67,7 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # Required to permit workflow git reset --hard during setup.
 # Set to "true" only when destructive git reset behavior is acceptable.
-# ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS=true
+ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS=true
 
 # Timeout for CodeRabbit review step in seconds (default: 600).
 # CODERABBIT_TIMEOUT_SECONDS=600

--- a/README.md
+++ b/README.md
@@ -41,6 +41,29 @@ uv run rouge --help
 Rouge loads a `.env` file from the current directory when available, otherwise
 from the parent directory, or directly from the shell environment.
 
+### Global vs per-workspace configuration
+
+The following environment variables are recommended to be set in your terminal
+profile (e.g., `~/.zshrc`) so they apply globally for all invocations of `rouge`
+and `rouge-worker`:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `ANTHROPIC_API_KEY`
+- `ROUGE_PROMPT_TIMEOUT`
+- `GITHUB_PAT`
+- `GITLAB_PAT`
+- `CODERABBIT_TIMEOUT_SECONDS`
+- `ROUGE_WORKFLOW_TIMEOUT_SECONDS`
+
+The only per-workspace or per-project configuration overrides that are
+recommended are the following (shown with their defaults in `.env.example`):
+
+- `DEV_SEC_OPS_PLATFORM=github`
+- `ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS=true`
+
+### Required Supabase credentials
+
 Required to talk to Supabase:
 
 - `SUPABASE_URL`

--- a/src/rouge/worker/cli.py
+++ b/src/rouge/worker/cli.py
@@ -177,8 +177,10 @@ def reset_worker(
 
 def main_entry() -> None:
     """Entry point for the rouge-worker CLI."""
+    from rouge.core.utils import _get_log_level
+
     logging.basicConfig(
-        level=logging.DEBUG,
+        level=_get_log_level(),
         format="%(message)s",
         handlers=[logging.StreamHandler(sys.stdout)],
     )


### PR DESCRIPTION
## Description

Add documentation recommending that environment variables like Supabase credentials, Anthropic API key, and platform tokens be set in the terminal profile (`~/.zshrc`) for global use across all `rouge` and `rouge-worker` invocations.

## Type of Change

- [x] Documentation

## What Changed

- Updated `README.md` with new section "Global vs per-workspace configuration" listing recommended global env vars
- Clarified that only `DEV_SEC_OPS_PLATFORM` and `ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS` are recommended as per-workspace overrides

## How to Test

Review the updated README section for clarity and accuracy.