### PR TITLE
fix(cli): allow issue reset for all non-claimed statuses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,9 +69,6 @@ DEV_SEC_OPS_PLATFORM=github
 # Set to "true" only when destructive git reset behavior is acceptable.
 ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS=true
 
-# Timeout for CodeRabbit review step in seconds (default: 600).
-# CODERABBIT_TIMEOUT_SECONDS=600
-
 # Worker default per-issue workflow timeout in seconds (default: 3600).
 # ROUGE_WORKFLOW_TIMEOUT_SECONDS=3600
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ and `rouge-worker`:
 - `ROUGE_PROMPT_TIMEOUT`
 - `GITHUB_PAT`
 - `GITLAB_PAT`
-- `CODERABBIT_TIMEOUT_SECONDS`
 - `ROUGE_WORKFLOW_TIMEOUT_SECONDS`
 
 The only per-workspace or per-project configuration overrides that are

--- a/src/rouge/cli/reset.py
+++ b/src/rouge/cli/reset.py
@@ -11,11 +11,10 @@ from rouge.core.database import fetch_issue, update_issue
 def reset(
     issue_id: int = typer.Argument(..., help="The issue ID to reset"),
 ) -> None:
-    """Reset a failed or pending issue back to pending status.
+    """Reset an issue back to pending status.
 
-    This command resets a failed or pending issue back to pending status, clears the
-    assigned_to field, and optionally clears the branch field depending on
-    the issue type.
+    This command resets an issue back to pending status, clears the assigned_to
+    field, and optionally clears the branch field depending on the issue type.
 
     Issue type behavior:
     - full: Clears branch and adw_id
@@ -23,7 +22,7 @@ def reset(
     - patch: Preserves existing branch, clears adw_id
     - direct: Preserves existing branch, clears adw_id
 
-    The issue must be in 'failed' or 'pending' status to be reset.
+    The issue must not be in 'claimed' status to be reset.
 
     Args:
         issue_id: The ID of the issue to reset
@@ -36,11 +35,11 @@ def reset(
         # Fetch the current issue
         issue = fetch_issue(issue_id)
 
-        # Validate issue status is 'failed' or 'pending'
-        if issue.status not in ("failed", "pending"):
+        # Validate issue status — 'claimed' cannot be reset
+        if issue.status == "claimed":
             typer.echo(
                 f"Error: Issue {issue_id} has status '{issue.status}', "
-                "can only reset 'failed' or 'pending' issues",
+                "cannot reset a 'claimed' issue",
                 err=True,
             )
             raise typer.Exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,71 +228,101 @@ def test_reset_command_with_pending_issue_succeeds(mock_fetch_issue, mock_update
 
 @patch("rouge.cli.reset.update_issue")
 @patch("rouge.cli.reset.fetch_issue")
-def test_reset_command_with_non_failed_issue_fails(mock_fetch_issue, mock_update_issue) -> None:
-    """Test 'rouge issue reset' with non-failed/non-pending issue fails with clear error."""
-    # Mock a started issue
+def test_reset_command_with_claimed_issue_fails(mock_fetch_issue, mock_update_issue) -> None:
+    """Test 'rouge issue reset' with claimed issue fails with clear error."""
     mock_issue = Issue(
         id=456,
         description="Test issue",
-        status="started",
+        status="claimed",
         type="full",
     )
     mock_fetch_issue.return_value = mock_issue
 
     result = runner.invoke(issue_app, ["reset", "456"])
     assert result.exit_code == 1
-    assert (
-        "Error: Issue 456 has status 'started', can only reset 'failed' or 'pending' issues"
-        in result.output
-    )
+    assert "Error: Issue 456 has status 'claimed', cannot reset a 'claimed' issue" in result.output
     mock_fetch_issue.assert_called_once_with(456)
     mock_update_issue.assert_not_called()
 
 
 @patch("rouge.cli.reset.update_issue")
 @patch("rouge.cli.reset.fetch_issue")
-def test_reset_command_with_started_issue_fails(mock_fetch_issue, mock_update_issue) -> None:
-    """Test 'rouge issue reset' with started issue fails."""
-    # Mock a started issue
+def test_reset_command_with_started_issue_succeeds(mock_fetch_issue, mock_update_issue) -> None:
+    """Test 'rouge issue reset' with started issue succeeds."""
     mock_issue = Issue(
         id=789,
         description="Test issue",
         status="started",
         type="full",
+        assigned_to="local-1",
+        branch="feature/wip",
+        adw_id="adw-abc",
     )
     mock_fetch_issue.return_value = mock_issue
 
-    result = runner.invoke(issue_app, ["reset", "789"])
-    assert result.exit_code == 1
-    assert (
-        "Error: Issue 789 has status 'started', can only reset 'failed' or 'pending' issues"
-        in result.output
+    updated_issue = Issue(
+        id=789,
+        description="Test issue",
+        status="pending",
+        type="full",
+        assigned_to=None,
+        branch=None,
+        adw_id=None,
     )
+    mock_update_issue.return_value = updated_issue
+
+    result = runner.invoke(issue_app, ["reset", "789"])
+    assert result.exit_code == 0
+    assert "789" in result.output
     mock_fetch_issue.assert_called_once_with(789)
-    mock_update_issue.assert_not_called()
+    mock_update_issue.assert_called_once_with(
+        789,
+        assigned_to=None,
+        status="pending",
+        branch=None,
+        adw_id=None,
+    )
 
 
 @patch("rouge.cli.reset.update_issue")
 @patch("rouge.cli.reset.fetch_issue")
-def test_reset_command_with_completed_issue_fails(mock_fetch_issue, mock_update_issue) -> None:
-    """Test 'rouge issue reset' with completed issue fails."""
-    # Mock a completed issue
+def test_reset_command_with_completed_issue_succeeds(mock_fetch_issue, mock_update_issue) -> None:
+    """Test 'rouge issue reset' with completed issue succeeds."""
+    # Mock a completed full issue
     mock_issue = Issue(
         id=321,
         description="Test issue",
         status="completed",
         type="full",
+        assigned_to="local-1",
+        branch="feature/done",
+        adw_id="adw-xyz",
     )
     mock_fetch_issue.return_value = mock_issue
 
-    result = runner.invoke(issue_app, ["reset", "321"])
-    assert result.exit_code == 1
-    assert (
-        "Error: Issue 321 has status 'completed', can only reset 'failed' or 'pending' issues"
-        in result.output
+    # Mock the updated issue
+    updated_issue = Issue(
+        id=321,
+        description="Test issue",
+        status="pending",
+        type="full",
+        assigned_to=None,
+        branch=None,
+        adw_id=None,
     )
+    mock_update_issue.return_value = updated_issue
+
+    result = runner.invoke(issue_app, ["reset", "321"])
+    assert result.exit_code == 0
+    assert "321" in result.output
     mock_fetch_issue.assert_called_once_with(321)
-    mock_update_issue.assert_not_called()
+    mock_update_issue.assert_called_once_with(
+        321,
+        assigned_to=None,
+        status="pending",
+        branch=None,
+        adw_id=None,
+    )
 
 
 @patch("rouge.cli.reset.update_issue")


### PR DESCRIPTION
## Description

Expands `rouge issue reset` to accept issues in `started` and `completed` status in addition to the existing `failed` and `pending`. The only status that cannot be reset is `claimed` (actively held by a worker).

## Type of Change

- [x] Bug fix / behavioral correction

## What Changed

- **`src/rouge/cli/reset.py`**: Guard condition changed from an allowlist (`failed`, `pending`) to a single blocklist check (`claimed`). Docstring and error message updated accordingly.
- **`tests/test_cli.py`**:
  - `test_reset_command_with_non_failed_issue_fails` → `test_reset_command_with_claimed_issue_fails` (repurposed to cover the only remaining invalid status)
  - `test_reset_command_with_started_issue_fails` → `test_reset_command_with_started_issue_succeeds`
  - `test_reset_command_with_completed_issue_fails` → `test_reset_command_with_completed_issue_succeeds`

## How to Test

```bash
# Reset a completed issue
rouge issue reset <id-of-completed-issue>

# Reset a started issue
rouge issue reset <id-of-started-issue>

# Claimed issues should still be blocked
rouge issue reset <id-of-claimed-issue>  # exits 1

# Run tests
uv run pytest tests/test_cli.py -v -k reset
```