### PR TITLE
fix(workflow): paginate GitLab note lookup to prevent duplicate attachment notes

### DIFF
--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -160,6 +160,98 @@ _TRUNCATION_NOTICE = "\n\n… *(content truncated to fit platform limits)*"
 
 _REVIEW_CONTEXT_MARKER = "<!-- rouge-review-context -->"
 
+_GLAB_NOTES_PAGE_SIZE = 100
+_GLAB_NOTES_MAX_PAGES = 50  # 5,000 notes ceiling; safety stop only
+
+
+def _find_existing_glab_marker_note_id(
+    repo_path: str,
+    mr_number: int,
+    env: dict[str, str],
+    logger: logging.Logger,
+) -> int | None:
+    for page in range(1, _GLAB_NOTES_MAX_PAGES + 1):
+        list_cmd = [
+            "glab",
+            "api",
+            f"projects/:id/merge_requests/{mr_number}/notes?page={page}&per_page={_GLAB_NOTES_PAGE_SIZE}",
+        ]
+        try:
+            result = subprocess.run(
+                list_cmd,
+                capture_output=True,
+                text=True,
+                cwd=repo_path,
+                env=env,
+                timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.warning(
+                "Failed to list review-context notes on MR !%d in %s "
+                "(phase=list-existing, page=%d): %s",
+                mr_number,
+                repo_path,
+                page,
+                _sanitize_for_logging(str(exc)),
+            )
+            return None
+
+        if result.returncode != 0:
+            logger.warning(
+                "Failed to list review-context notes on MR !%d in %s "
+                "(phase=list-existing, page=%d, exit_code=%d): %s",
+                mr_number,
+                repo_path,
+                page,
+                result.returncode,
+                _sanitize_for_logging(result.stderr),
+            )
+            return None
+
+        if not result.stdout.strip():
+            return None
+
+        try:
+            notes = json.loads(result.stdout)
+        except ValueError:
+            logger.warning(
+                "Malformed JSON listing review-context notes on MR !%d in %s "
+                "(phase=list-existing, page=%d)",
+                mr_number,
+                repo_path,
+                page,
+            )
+            return None
+
+        if not isinstance(notes, list):
+            logger.warning(
+                "Unexpected payload listing review-context notes on MR !%d in %s "
+                "(phase=list-existing, page=%d)",
+                mr_number,
+                repo_path,
+                page,
+            )
+            return None
+
+        for note in notes:
+            if not isinstance(note, dict):
+                continue
+            if note.get("body", "").startswith(_REVIEW_CONTEXT_MARKER):
+                try:
+                    return int(note["id"])
+                except (KeyError, TypeError, ValueError):
+                    continue
+
+        if len(notes) < _GLAB_NOTES_PAGE_SIZE:
+            return None
+
+    logger.warning(
+        "Reached %d-page cap searching review-context note on MR !%d",
+        _GLAB_NOTES_MAX_PAGES,
+        mr_number,
+    )
+    return None
+
 
 def render_attachment_markdown(
     spec_text: str | None,
@@ -417,26 +509,7 @@ def post_glab_attachment_note(
     logger = get_logger(__name__)
     tagged_body = f"{_REVIEW_CONTEXT_MARKER}\n{body}"
 
-    # NOTE: per_page=100 without pagination; duplicates possible on MRs with 100+ notes.
-    list_cmd = [
-        "glab",
-        "api",
-        f"projects/:id/merge_requests/{mr_number}/notes?per_page=100",
-    ]
-    result = subprocess.run(
-        list_cmd, capture_output=True, text=True, cwd=repo_path, env=env, timeout=30
-    )
-
-    existing_note_id = None
-    if result.returncode == 0 and result.stdout.strip():
-        try:
-            notes = json.loads(result.stdout)
-            for note in notes:
-                if note.get("body", "").startswith(_REVIEW_CONTEXT_MARKER):
-                    existing_note_id = int(note["id"])
-                    break
-        except (ValueError, KeyError, TypeError, AttributeError):
-            logger.debug("Failed to parse GitLab notes response for MR !%d", mr_number)
+    existing_note_id = _find_existing_glab_marker_note_id(repo_path, mr_number, env, logger)
 
     if existing_note_id:
         update_cmd = [

--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -168,8 +168,8 @@ def _find_existing_glab_marker_note_id(
     repo_path: str,
     mr_number: int,
     env: dict[str, str],
-    logger: logging.Logger,
 ) -> int | None:
+    logger = get_logger(__name__)
     for page in range(1, _GLAB_NOTES_MAX_PAGES + 1):
         list_cmd = [
             "glab",
@@ -240,7 +240,12 @@ def _find_existing_glab_marker_note_id(
                 try:
                     return int(note["id"])
                 except (KeyError, TypeError, ValueError):
-                    continue
+                    logger.warning(
+                        "Marker note on MR !%d has unparseable id: %r",
+                        mr_number,
+                        note.get("id"),
+                    )
+                    return None
 
         if len(notes) < _GLAB_NOTES_PAGE_SIZE:
             return None
@@ -509,9 +514,9 @@ def post_glab_attachment_note(
     logger = get_logger(__name__)
     tagged_body = f"{_REVIEW_CONTEXT_MARKER}\n{body}"
 
-    existing_note_id = _find_existing_glab_marker_note_id(repo_path, mr_number, env, logger)
+    existing_note_id = _find_existing_glab_marker_note_id(repo_path, mr_number, env)
 
-    if existing_note_id:
+    if existing_note_id is not None:
         update_cmd = [
             "glab",
             "api",

--- a/tests/test_attachment_note_helpers.py
+++ b/tests/test_attachment_note_helpers.py
@@ -1,0 +1,197 @@
+"""End-to-end tests for ``post_glab_attachment_note`` pagination behavior.
+
+These tests drive ``post_glab_attachment_note`` with a patched
+``subprocess.run`` and assert on the observed call sequence. They exercise the
+private ``_find_existing_glab_marker_note_id`` helper indirectly so the public
+contract stays the test surface.
+"""
+
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rouge.core.workflow.step_utils import (
+    _REVIEW_CONTEXT_MARKER,
+    post_glab_attachment_note,
+)
+
+_LOGGER_NAME = "rouge.core.workflow.step_utils"
+_REPO_PATH = "/tmp/fake-repo"
+_MR_NUMBER = 42
+_BODY = "rendered body"
+_ENV = {"GITLAB_TOKEN": "fake"}
+
+
+def _make_note(note_id: int, *, marker: bool = False) -> dict:
+    body = (
+        f"{_REVIEW_CONTEXT_MARKER}\nold content" if marker else f"some unrelated comment {note_id}"
+    )
+    return {"id": note_id, "body": body}
+
+
+def _ok(stdout: str = "") -> MagicMock:
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = stdout
+    result.stderr = ""
+    return result
+
+
+def _classify(cmd: list[str]) -> str:
+    """Return a short tag describing which subprocess branch was invoked."""
+    cmd_str = " ".join(cmd)
+    if "api" in cmd_str and "notes?page=1" in cmd_str:
+        return "list_page_1"
+    if "api" in cmd_str and "notes?page=2" in cmd_str:
+        return "list_page_2"
+    if "api" in cmd_str and "PUT" in cmd_str:
+        return "put_update"
+    if "mr" in cmd_str and "note" in cmd_str:
+        return "create_note"
+    return "unknown"
+
+
+def _build_side_effect(page_responses: dict[str, MagicMock]):
+    """Return a side_effect that maps classified calls to canned responses."""
+
+    def _side_effect(cmd: list[str], **_kwargs: object) -> MagicMock:
+        tag = _classify(cmd)
+        if tag in page_responses:
+            response = page_responses[tag]
+            if isinstance(response, Exception):
+                raise response
+            return response
+        # Default: PUT and create both succeed.
+        if tag == "put_update":
+            return _ok()
+        if tag == "create_note":
+            return _ok()
+        return _ok()
+
+    return _side_effect
+
+
+def _calls_by_tag(mock_run: MagicMock) -> dict[str, list[list[str]]]:
+    """Group recorded subprocess.run call commands by classification tag."""
+    grouped: dict[str, list[list[str]]] = {}
+    for call in mock_run.call_args_list:
+        cmd = call.args[0] if call.args else call.kwargs.get("args")
+        tag = _classify(cmd)
+        grouped.setdefault(tag, []).append(cmd)
+    return grouped
+
+
+def test_first_page_match_triggers_update() -> None:
+    page_1_notes = [_make_note(i) for i in range(1, 51)]
+    page_1_notes[4] = _make_note(500, marker=True)  # 5th note carries marker
+    side_effect = _build_side_effect({"list_page_1": _ok(json.dumps(page_1_notes))})
+
+    with patch(
+        "rouge.core.workflow.step_utils.subprocess.run", side_effect=side_effect
+    ) as mock_run:
+        post_glab_attachment_note(_REPO_PATH, _MR_NUMBER, _BODY, _ENV)
+
+    grouped = _calls_by_tag(mock_run)
+    assert len(grouped.get("list_page_1", [])) == 1
+    assert "list_page_2" not in grouped
+    assert len(grouped.get("put_update", [])) == 1
+    assert "create_note" not in grouped
+    put_cmd = grouped["put_update"][0]
+    assert any("notes/500" in part for part in put_cmd)
+
+
+def test_second_page_match_triggers_update() -> None:
+    page_1_notes = [_make_note(i) for i in range(1, 101)]
+    page_2_notes = [_make_note(i) for i in range(101, 131)]
+    page_2_notes[10] = _make_note(777, marker=True)
+    side_effect = _build_side_effect(
+        {
+            "list_page_1": _ok(json.dumps(page_1_notes)),
+            "list_page_2": _ok(json.dumps(page_2_notes)),
+        }
+    )
+
+    with patch(
+        "rouge.core.workflow.step_utils.subprocess.run", side_effect=side_effect
+    ) as mock_run:
+        post_glab_attachment_note(_REPO_PATH, _MR_NUMBER, _BODY, _ENV)
+
+    grouped = _calls_by_tag(mock_run)
+    assert len(grouped.get("list_page_1", [])) == 1
+    assert len(grouped.get("list_page_2", [])) == 1
+    assert len(grouped.get("put_update", [])) == 1
+    assert "create_note" not in grouped
+    put_cmd = grouped["put_update"][0]
+    assert any("notes/777" in part for part in put_cmd)
+
+
+def test_no_match_creates_note() -> None:
+    page_1_notes = [_make_note(i) for i in range(1, 101)]
+    page_2_notes = [_make_note(i) for i in range(101, 151)]
+    side_effect = _build_side_effect(
+        {
+            "list_page_1": _ok(json.dumps(page_1_notes)),
+            "list_page_2": _ok(json.dumps(page_2_notes)),
+        }
+    )
+
+    with patch(
+        "rouge.core.workflow.step_utils.subprocess.run", side_effect=side_effect
+    ) as mock_run:
+        post_glab_attachment_note(_REPO_PATH, _MR_NUMBER, _BODY, _ENV)
+
+    grouped = _calls_by_tag(mock_run)
+    assert len(grouped.get("list_page_1", [])) == 1
+    assert len(grouped.get("list_page_2", [])) == 1
+    assert "put_update" not in grouped
+    assert len(grouped.get("create_note", [])) == 1
+    create_cmd = grouped["create_note"][0]
+    # Marker should appear in the create message body.
+    assert any(_REVIEW_CONTEXT_MARKER in part for part in create_cmd)
+
+
+def test_list_failure_falls_back_to_create(caplog: pytest.LogCaptureFixture) -> None:
+    failed = MagicMock()
+    failed.returncode = 1
+    failed.stdout = ""
+    failed.stderr = "boom: gitlab unavailable"
+    side_effect = _build_side_effect({"list_page_1": failed})
+
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    with patch(
+        "rouge.core.workflow.step_utils.subprocess.run", side_effect=side_effect
+    ) as mock_run:
+        post_glab_attachment_note(_REPO_PATH, _MR_NUMBER, _BODY, _ENV)
+
+    grouped = _calls_by_tag(mock_run)
+    assert len(grouped.get("list_page_1", [])) == 1
+    assert "list_page_2" not in grouped
+    assert "put_update" not in grouped
+    assert len(grouped.get("create_note", [])) == 1
+    # Warning should mention the page that failed.
+    warning_messages = [
+        rec.getMessage() for rec in caplog.records if rec.levelno == logging.WARNING
+    ]
+    assert any("page=1" in msg for msg in warning_messages)
+
+
+def test_malformed_json_falls_back_to_create(caplog: pytest.LogCaptureFixture) -> None:
+    side_effect = _build_side_effect({"list_page_1": _ok("not json")})
+
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    with patch(
+        "rouge.core.workflow.step_utils.subprocess.run", side_effect=side_effect
+    ) as mock_run:
+        post_glab_attachment_note(_REPO_PATH, _MR_NUMBER, _BODY, _ENV)
+
+    grouped = _calls_by_tag(mock_run)
+    assert len(grouped.get("list_page_1", [])) == 1
+    assert "list_page_2" not in grouped
+    assert "put_update" not in grouped
+    assert len(grouped.get("create_note", [])) == 1
+    warning_messages = [
+        rec.getMessage() for rec in caplog.records if rec.levelno == logging.WARNING
+    ]
+    assert any("Malformed" in msg for msg in warning_messages)

--- a/tests/test_attachment_note_helpers.py
+++ b/tests/test_attachment_note_helpers.py
@@ -8,6 +8,7 @@ contract stays the test surface.
 
 import json
 import logging
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,7 +25,7 @@ _BODY = "rendered body"
 _ENV = {"GITLAB_TOKEN": "fake"}
 
 
-def _make_note(note_id: int, *, marker: bool = False) -> dict:
+def _make_note(note_id: int, *, marker: bool = False) -> dict[str, object]:
     body = (
         f"{_REVIEW_CONTEXT_MARKER}\nold content" if marker else f"some unrelated comment {note_id}"
     )
@@ -41,19 +42,20 @@ def _ok(stdout: str = "") -> MagicMock:
 
 def _classify(cmd: list[str]) -> str:
     """Return a short tag describing which subprocess branch was invoked."""
-    cmd_str = " ".join(cmd)
-    if "api" in cmd_str and "notes?page=1" in cmd_str:
-        return "list_page_1"
-    if "api" in cmd_str and "notes?page=2" in cmd_str:
-        return "list_page_2"
-    if "api" in cmd_str and "PUT" in cmd_str:
+    if cmd[:2] == ["glab", "api"] and "--method" in cmd and "PUT" in cmd:
         return "put_update"
-    if "mr" in cmd_str and "note" in cmd_str:
+    if cmd[:2] == ["glab", "api"]:
+        for token in cmd:
+            if "notes?page=1" in token:
+                return "list_page_1"
+            if "notes?page=2" in token:
+                return "list_page_2"
+    if len(cmd) >= 3 and cmd[:3] == ["glab", "mr", "note"]:
         return "create_note"
     return "unknown"
 
 
-def _build_side_effect(page_responses: dict[str, MagicMock]):
+def _build_side_effect(page_responses: dict[str, MagicMock]) -> Callable[..., MagicMock]:
     """Return a side_effect that maps classified calls to canned responses."""
 
     def _side_effect(cmd: list[str], **_kwargs: object) -> MagicMock:


### PR DESCRIPTION
## Description

The previous `post_glab_attachment_note` implementation fetched only the first page of MR notes (hard-coded `per_page=100`) with no pagination loop. On MRs with more than 100 existing notes, the review-context marker note would never be found, causing a duplicate note to be created on every run instead of updating the existing one.

This fix extracts the lookup into a dedicated `_find_existing_glab_marker_note_id` helper that paginates through up to `_GLAB_NOTES_MAX_PAGES` (50) pages — a ceiling of 5,000 notes. Any page-level error or malformed JSON response logs a structured warning and causes the caller to fall back to creating a new note.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## What Changed

- Added `_GLAB_NOTES_PAGE_SIZE = 100` and `_GLAB_NOTES_MAX_PAGES = 50` module-level constants defining pagination bounds
- Extracted note-lookup logic from `post_glab_attachment_note` into a new `_find_existing_glab_marker_note_id` helper with a full pagination loop, per-page error handling, and structured `logger.warning` calls
- Added `tests/test_attachment_note_helpers.py` with five tests: first-page match triggers update, second-page match triggers update, no match creates a new note, list-failure fallback to create, and malformed-JSON fallback to create

## How to Test

- [ ] Run `pytest tests/test_attachment_note_helpers.py` and verify all five tests pass
- [ ] Trigger a code-review workflow against a GitLab MR that already has 100+ notes and confirm the existing review-context note is updated rather than a duplicate being created
