### PR TITLE
docs(workflow): update get_patch_pipeline docstring for GitCheckoutStep

### DIFF
--- a/src/rouge/core/workflow/pipeline.py
+++ b/src/rouge/core/workflow/pipeline.py
@@ -308,13 +308,17 @@ def get_patch_pipeline() -> List[WorkflowStep]:
     from any parent or prior workflow.
 
     The patch workflow sequence is:
-    1. FetchPatchStep - Fetch the patch issue from the database; writes PatchArtifact
-    2. BuildPatchPlanStep - Build a standalone plan from the patch issue description;
+    1. FetchPatchStep - Fetch the patch issue from the database; writes
+       FetchPatchArtifact for downstream steps in this workflow's artifact directory
+    2. GitCheckoutStep - Check out the existing branch associated with the patch
+       issue (resolved from the FetchPatchArtifact) so subsequent steps operate on
+       the correct PR/MR branch
+    3. PatchPlanStep - Build a standalone plan from the patch issue description;
        writes a standard PlanArtifact (no parent issue or plan is referenced)
-    3. ImplementPlanStep - Implement the plan by loading PlanArtifact from the current
-       patch workflow's artifact directory
-    4. CodeQualityStep - Run code quality checks
-    5. ComposeCommitsStep - Push commits to the existing PR/MR branch; detects the
+    4. ImplementPlanStep - Implement the plan by loading PlanArtifact from the
+       current patch workflow's artifact directory
+    5. CodeQualityStep - Run code quality checks on the implementation
+    6. ComposeCommitsStep - Push commits to the existing PR/MR branch; detects the
        PR/MR via git CLI tools (gh/glab) rather than loading parent artifacts
 
     Returns:


### PR DESCRIPTION
## Description

Updates the `get_patch_pipeline()` docstring in `pipeline.py` to accurately reflect the current patch pipeline structure, including the renamed `FetchPatchArtifact`, the addition of `GitCheckoutStep`, the renamed `PatchPlanStep`, and corrected step numbering.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Renamed `PatchArtifact` → `FetchPatchArtifact` in step 1 description to match actual artifact name
- Added `GitCheckoutStep` as step 2 (checks out the PR/MR branch resolved from `FetchPatchArtifact`)
- Renamed `BuildPatchPlanStep` → `PatchPlanStep` (now step 3) to match actual class name
- Renumbered `ImplementPlanStep` → step 4, `CodeQualityStep` → step 5, `ComposeCommitsStep` → step 6
- Added minor wording clarifications throughout

## How to Test

- [ ] Review the updated docstring in `src/rouge/core/workflow/pipeline.py` matches the actual `get_patch_pipeline()` return value steps