### PR TITLE
fix(workflow): hoist Pydantic JSON schema definitions to root for Claude Code compatibility

### DIFF
--- a/src/rouge/core/workflow/step_utils.py
+++ b/src/rouge/core/workflow/step_utils.py
@@ -138,18 +138,23 @@ def build_repos_schema(repo_submodel: Type[_M], output_const: str) -> str:
         A ``json.dumps``-rendered JSON Schema string, indented with 2 spaces,
         ready to be embedded in a prompt template.
     """
-    return json.dumps(
-        {
-            "type": "object",
-            "properties": {
-                "output": {"type": "string", "const": output_const},
-                "repos": {
-                    "type": "array",
-                    "items": repo_submodel.model_json_schema(),
-                },
+    item_schema = repo_submodel.model_json_schema()
+    definitions = item_schema.pop("$defs", None)
+    schema: Dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "output": {"type": "string", "const": output_const},
+            "repos": {
+                "type": "array",
+                "items": item_schema,
             },
-            "required": ["output", "repos"],
         },
+        "required": ["output", "repos"],
+    }
+    if definitions:
+        schema["$defs"] = definitions
+    return json.dumps(
+        schema,
         indent=2,
     )
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,7 +1,9 @@
 """Tests for workflow orchestration."""
 
+import json
 import tempfile
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -165,6 +167,82 @@ def test_code_quality_step_passes_json_schema(mock_execute, mock_emit) -> None:
     request = mock_execute.call_args[0][0]
     assert request.json_schema is not None
     assert '"const": "code-quality"' in request.json_schema
+
+
+def _collect_local_refs(value: Any) -> list[str]:
+    """Collect all local JSON Schema ``$ref`` pointers from a schema fragment."""
+    refs: list[str] = []
+    if isinstance(value, dict):
+        ref = value.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/"):
+            refs.append(ref)
+        for child in value.values():
+            refs.extend(_collect_local_refs(child))
+    elif isinstance(value, list):
+        for child in value:
+            refs.extend(_collect_local_refs(child))
+    return refs
+
+
+def _resolve_json_pointer(schema: dict[str, Any], pointer: str) -> Any:
+    """Resolve a local JSON pointer against *schema* and assert it is valid."""
+    current: Any = schema
+    for raw_segment in pointer[2:].split("/"):
+        segment = raw_segment.replace("~1", "/").replace("~0", "~")
+        assert isinstance(current, dict)
+        assert segment in current
+        current = current[segment]
+    return current
+
+
+@pytest.mark.parametrize(
+    ("schema_name", "schema_json", "output_const", "expected_definition"),
+    [
+        (
+            "code-quality",
+            "rouge.core.workflow.steps.code_quality_step",
+            "code-quality",
+            "CodeQualityIssue",
+        ),
+        (
+            "compose-request",
+            "rouge.core.workflow.steps.compose_request_step",
+            "pull-request",
+            "CommitEntry",
+        ),
+        (
+            "compose-commits",
+            "rouge.core.workflow.steps.compose_commits_step",
+            "compose-commits",
+            "CommitEntry",
+        ),
+    ],
+)
+def test_generated_repos_schemas_hoist_defs_to_root(
+    schema_name: str,
+    schema_json: str,
+    output_const: str,
+    expected_definition: str,
+) -> None:
+    """Generated repos schemas keep local refs resolvable from the schema root."""
+    import importlib
+
+    module = importlib.import_module(schema_json)
+    schema_attr = {
+        "code-quality": "CODE_QUALITY_JSON_SCHEMA",
+        "compose-request": "PULL_REQUEST_JSON_SCHEMA",
+        "compose-commits": "COMPOSE_COMMITS_JSON_SCHEMA",
+    }[schema_name]
+    schema = json.loads(getattr(module, schema_attr))
+
+    assert schema["properties"]["output"]["const"] == output_const
+    assert expected_definition in schema["$defs"]
+    assert "$defs" not in schema["properties"]["repos"]["items"]
+
+    refs = _collect_local_refs(schema)
+    assert refs
+    for ref in refs:
+        assert _resolve_json_pointer(schema, ref)
 
 
 # === GhPullRequestStep Tests ===


### PR DESCRIPTION
## Description

This PR fixes the JSON schema generation used by three orchestrator steps (code-quality, compose-request, compose-commits) so that Claude Code can validate the schemas and return structured output.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Test improvement

## Problem

The shared `build_repos_schema()` helper embedded Pydantic's `model_json_schema()` output directly under `repos.items`, leaving `` nested inside the items object. Claude Code's JSON schema validator requires `` at the document root for local `` pointers like `#/$defs/CodeQualityIssue` to resolve.

This caused the affected steps to fail with:

```
Missing 'structured_output' in envelope
```

Claude Code completed successfully but returned an envelope without the `structured_output` field because it could not validate the schema.

## Solution

- Extract `` from the item schema and add to root if present
- Keep `repos.items` free of nested ``
- All local `` pointers now resolve from the schema root

## What Changed

- `src/rouge/core/workflow/step_utils.py`: Updated `build_repos_schema()` to hoist ``
- `tests/test_workflow.py`: Added regression test covering all three generated schemas

## How to Test

1. `uv run ruff check src/` - all checks pass
2. `uv run mypy` - no type errors
3. `uv run pytest tests/ -v` - all tests pass (1129 passed, 7 skipped)
4. Schema validation:
   ```python
   import json
   from rouge.core.workflow.steps.code_quality_step import CODE_QUALITY_JSON_SCHEMA
   schema = json.loads(CODE_QUALITY_JSON_SCHEMA)
   assert "$defs" in schema  # Root has definitions
   assert "$defs" not in schema["properties"]["repos"]["items"]  # Items does not
   ```

## Affected Steps

- `code-quality` - now returns structured output from Claude Code
- `compose-request` (pull-request) - now returns structured output from Claude Code
- `compose-commits` - now returns structured output from Claude Code