### PR TITLE
fix(workflow): surface PR/MR creation failures as failed StepResult

### DIFF
--- a/src/rouge/core/workflow/pull_request_step_base.py
+++ b/src/rouge/core/workflow/pull_request_step_base.py
@@ -283,12 +283,16 @@ class PullRequestStepBase(WorkflowStep, ABC):
         pull_requests: list[PullRequestEntry],
         env: dict[str, str],
         attachment_md: str | None,
-    ) -> None:
+    ) -> bool | None:
         """Process a single repository for PR/MR creation.
 
         Checks for existing PRs/MRs, pushes the branch, and creates a new
         one.  Mutates *pull_requests* in-place when a PR/MR is adopted or
         created.
+
+        Returns ``True`` when a PR/MR is successfully created, ``False`` when
+        creation was attempted but failed, and ``None`` for intentional skip
+        paths (already-done, adopt-existing succeeded, no branch delta).
         """
         logger = get_logger(context.adw_id)
         repo_name = os.path.basename(os.path.normpath(repo_path))
@@ -302,7 +306,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
                 repo_name,
                 repo_path,
             )
-            return
+            return None
 
         # Determine the current branch name for this repo
         try:
@@ -322,7 +326,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
         if branch_name and self._try_adopt_existing(
             context, repo_path, branch_name, pull_requests, env, attachment_md
         ):
-            return
+            return None
 
         # Layer 2.5: Branch-delta guard -- skip creation if no commits ahead of base
         if not has_branch_delta(repo_path, context.adw_id):
@@ -331,7 +335,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
                 repo_path,
                 self.entity_name,
             )
-            return
+            return None
 
         # Layer 3: Push + create new PR/MR
         push_cmd = ["git", "push", "--set-upstream", "origin", "HEAD"]
@@ -390,7 +394,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
                 error_msg,
                 {"output": f"{self.output_key_prefix}-failed", "error": error_msg},
             )
-            return
+            return False
 
         if result.returncode != 0:
             error_msg = (
@@ -412,7 +416,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
                 {"output": f"{self.output_key_prefix}-failed", "error": error_msg},
             )
             # Continue to next repo; partial progress is already saved
-            return
+            return False
 
         # Parse URL and number from create command output
         parsed = self._parse_create_output(result.stdout)
@@ -424,7 +428,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
                 repo_name,
                 result.stdout,
             )
-            return
+            return False
 
         item_url, item_number = parsed
         repo_display_name = extract_repo_from_pull_request_url(item_url) or repo_name
@@ -469,6 +473,8 @@ class PullRequestStepBase(WorkflowStep, ABC):
                     entry.number,
                     exc,
                 )
+
+        return True
 
     def _seed_pull_requests(self, context: WorkflowContext) -> list[PullRequestEntry]:
         """Load existing pull request entries from the artifact store for rerun continuity.
@@ -558,7 +564,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
         env: dict[str, str],
         attachment_md: str | None,
         logger: logging.Logger,
-    ) -> bool:
+    ) -> tuple[bool, bool]:
         """Iterate *affected_repos* and dispatch each matched entry to ``_process_repo``.
 
         Logs a warning for repos with no matching PR-details entry and an info
@@ -576,9 +582,12 @@ class PullRequestStepBase(WorkflowStep, ABC):
             logger: Logger for the current workflow run.
 
         Returns:
-            ``True`` if at least one repo was dispatched; ``False`` otherwise.
+            ``(dispatched_any, failed_any)`` where ``dispatched_any`` is ``True``
+            when at least one repo was dispatched, and ``failed_any`` is ``True``
+            when at least one dispatched repo attempted creation and failed.
         """
         dispatched_any = False
+        failed_any = False
         lookup_misses = 0
         empty_title_skips = 0
 
@@ -603,7 +612,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
                 empty_title_skips += 1
                 continue
             dispatched_any = True
-            self._process_repo(
+            repo_result = self._process_repo(
                 context,
                 repo_path,
                 title,
@@ -612,6 +621,8 @@ class PullRequestStepBase(WorkflowStep, ABC):
                 env,
                 attachment_md,
             )
+            if repo_result is False:
+                failed_any = True
 
         if not dispatched_any:
             if empty_title_skips > 0 and lookup_misses == 0:
@@ -638,7 +649,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
                 {"output": f"{self.output_key_prefix}-skipped", "reason": skip_msg},
             )
 
-        return dispatched_any
+        return dispatched_any, failed_any
 
     def _execute_pr_creation(
         self,
@@ -684,7 +695,7 @@ class PullRequestStepBase(WorkflowStep, ABC):
                 context.artifact_store.write_artifact(artifact)
             return StepResult.ok(None)
 
-        dispatched_any = self._dispatch_repos(
+        dispatched_any, failed_any = self._dispatch_repos(
             context,
             affected_repos,
             pr_by_repo,
@@ -719,6 +730,10 @@ class PullRequestStepBase(WorkflowStep, ABC):
                 f"{self.entity_name}(s) created: {', '.join(urls)}",
                 comment_data,
             )
+
+        if failed_any:
+            error_msg = f"{self.entity_name} creation failed for one or more repos"
+            return StepResult.fail(error_msg)
 
         return StepResult.ok(None)
 

--- a/tests/test_gh_pull_request_step.py
+++ b/tests/test_gh_pull_request_step.py
@@ -981,3 +981,216 @@ class TestGhPullRequestStepAttachment:
             1,
             "HTTP 403: Forbidden",
         )
+
+
+class TestGhPullRequestStepFailure:
+    """Tests verifying GhPullRequestStep returns failed StepResult when create fails."""
+
+    @patch("rouge.core.workflow.pull_request_step_base._emit_and_log")
+    @patch("rouge.core.workflow.pull_request_step_base.emit_artifact_comment")
+    @patch("rouge.core.workflow.pull_request_step_base.log_artifact_comment_status")
+    @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
+    @patch("rouge.core.workflow.pull_request_step_base.subprocess.run")
+    @patch.dict("os.environ", {"GITHUB_PAT": "tok", "PATH": "/usr/bin"}, clear=True)
+    def test_non_zero_create_exit_returns_failed_step_result(
+        self,
+        mock_run: MagicMock,
+        mock_which: MagicMock,
+        _mock_log: MagicMock,
+        mock_emit_artifact: MagicMock,
+        mock_emit: MagicMock,
+        base_context: WorkflowContext,
+        store: ArtifactStore,
+    ) -> None:
+        """Non-zero gh pr create exit code results in a failed StepResult."""
+        store.write_artifact(
+            ComposeRequestArtifact(
+                workflow_id="test-gh-pr",
+                repos=[
+                    {
+                        "repo": "/path/to/repo",
+                        "title": "Test PR",
+                        "summary": "Summary",
+                        "commits": [],
+                    }
+                ],
+            )
+        )
+        mock_which.return_value = "/usr/bin/gh"
+        mock_emit_artifact.return_value = ("success", "ok")
+
+        def _side_effect(cmd: list[str], **_kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            if cmd[0] == "git" and cmd[1] == "rev-parse":
+                result.returncode = 0
+                result.stdout = "feature-branch"
+            elif cmd[0] == "gh" and cmd[1] == "pr" and cmd[2] == "list":
+                result.returncode = 0
+                result.stdout = "[]"
+            elif cmd[0] == "git" and cmd[1] == "push":
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+            elif cmd[0] == "gh" and cmd[1] == "pr" and cmd[2] == "create":
+                result.returncode = 1
+                result.stdout = ""
+                result.stderr = "gh: HTTP 422"
+            else:
+                result.returncode = 0
+                result.stdout = ""
+            return result
+
+        mock_run.side_effect = _side_effect
+
+        step = GhPullRequestStep()
+        result = step.run(base_context)
+
+        assert result.success is False
+        assert result.error is not None
+        assert "creation failed for one or more repos" in result.error
+
+    @patch("rouge.core.workflow.pull_request_step_base._emit_and_log")
+    @patch("rouge.core.workflow.pull_request_step_base.emit_artifact_comment")
+    @patch("rouge.core.workflow.pull_request_step_base.log_artifact_comment_status")
+    @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
+    @patch("rouge.core.workflow.pull_request_step_base.subprocess.run")
+    @patch.dict("os.environ", {"GITHUB_PAT": "tok", "PATH": "/usr/bin"}, clear=True)
+    def test_unparseable_create_output_returns_failed_step_result(
+        self,
+        mock_run: MagicMock,
+        mock_which: MagicMock,
+        _mock_log: MagicMock,
+        mock_emit_artifact: MagicMock,
+        mock_emit: MagicMock,
+        base_context: WorkflowContext,
+        store: ArtifactStore,
+    ) -> None:
+        """Successful exit but unparseable gh pr create output results in failed StepResult."""
+        store.write_artifact(
+            ComposeRequestArtifact(
+                workflow_id="test-gh-pr",
+                repos=[
+                    {
+                        "repo": "/path/to/repo",
+                        "title": "Test PR",
+                        "summary": "Summary",
+                        "commits": [],
+                    }
+                ],
+            )
+        )
+        mock_which.return_value = "/usr/bin/gh"
+        mock_emit_artifact.return_value = ("success", "ok")
+
+        def _side_effect(cmd: list[str], **_kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            if cmd[0] == "git" and cmd[1] == "rev-parse":
+                result.returncode = 0
+                result.stdout = "feature-branch"
+            elif cmd[0] == "gh" and cmd[1] == "pr" and cmd[2] == "list":
+                result.returncode = 0
+                result.stdout = "[]"
+            elif cmd[0] == "git" and cmd[1] == "push":
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+            elif cmd[0] == "gh" and cmd[1] == "pr" and cmd[2] == "create":
+                result.returncode = 0
+                result.stdout = "   \n"
+            else:
+                result.returncode = 0
+                result.stdout = ""
+            return result
+
+        mock_run.side_effect = _side_effect
+
+        step = GhPullRequestStep()
+        result = step.run(base_context)
+
+        assert result.success is False
+        assert result.error is not None
+        assert "creation failed for one or more repos" in result.error
+
+    @patch("rouge.core.workflow.pull_request_step_base._emit_and_log")
+    @patch("rouge.core.workflow.pull_request_step_base.emit_artifact_comment")
+    @patch("rouge.core.workflow.pull_request_step_base.log_artifact_comment_status")
+    @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
+    @patch("rouge.core.workflow.pull_request_step_base.subprocess.run")
+    @patch("rouge.core.workflow.pull_request_step_base.get_affected_repo_paths")
+    @patch.dict("os.environ", {"GITHUB_PAT": "tok", "PATH": "/usr/bin"}, clear=True)
+    def test_multi_repo_first_success_second_failure(
+        self,
+        mock_get_affected: MagicMock,
+        mock_run: MagicMock,
+        mock_which: MagicMock,
+        _mock_log: MagicMock,
+        mock_emit_artifact: MagicMock,
+        mock_emit: MagicMock,
+        base_context: WorkflowContext,
+        store: ArtifactStore,
+    ) -> None:
+        """First repo succeeds (artifact written); second repo fails; run() returns failed."""
+        store.write_artifact(
+            ComposeRequestArtifact(
+                workflow_id="test-gh-pr",
+                repos=[
+                    {
+                        "repo": "/path/to/repo-a",
+                        "title": "PR A",
+                        "summary": "Summary A",
+                        "commits": [],
+                    },
+                    {
+                        "repo": "/path/to/repo-b",
+                        "title": "PR B",
+                        "summary": "Summary B",
+                        "commits": [],
+                    },
+                ],
+            )
+        )
+        mock_which.return_value = "/usr/bin/gh"
+        mock_emit_artifact.return_value = ("success", "ok")
+
+        base_context.repo_paths = ["/path/to/repo-a", "/path/to/repo-b"]
+        mock_get_affected.return_value = ["/path/to/repo-a", "/path/to/repo-b"]
+
+        def _side_effect(cmd: list[str], **kwargs: Any) -> MagicMock:
+            cwd = str(kwargs.get("cwd", ""))
+            result = MagicMock()
+            if cmd[0] == "git" and cmd[1] == "rev-parse":
+                result.returncode = 0
+                result.stdout = "feature-branch"
+            elif cmd[0] == "gh" and cmd[1] == "pr" and cmd[2] == "list":
+                result.returncode = 0
+                result.stdout = "[]"
+            elif cmd[0] == "git" and cmd[1] == "push":
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+            elif cmd[0] == "gh" and cmd[1] == "pr" and cmd[2] == "create":
+                if "repo-a" in cwd:
+                    result.returncode = 0
+                    result.stdout = "https://github.com/org/repo-a/pull/1"
+                else:
+                    result.returncode = 1
+                    result.stdout = ""
+                    result.stderr = "gh: HTTP 422"
+            else:
+                result.returncode = 0
+                result.stdout = ""
+            return result
+
+        mock_run.side_effect = _side_effect
+
+        step = GhPullRequestStep()
+        result = step.run(base_context)
+
+        assert result.success is False
+        assert result.error is not None
+        assert "creation failed for one or more repos" in result.error
+
+        # First repo's PR should still have been written to the artifact
+        artifact = store.read_artifact("gh-pull-request")
+        assert len(artifact.pull_requests) == 1
+        assert artifact.pull_requests[0].url == "https://github.com/org/repo-a/pull/1"

--- a/tests/test_glab_pull_request_step.py
+++ b/tests/test_glab_pull_request_step.py
@@ -786,3 +786,210 @@ class TestGlabPullRequestStepAttachment:
 
         # Step should still succeed despite attachment posting failure
         assert result.success is True
+
+
+class TestGlabPullRequestStepFailure:
+    """Tests verifying GlabPullRequestStep returns failed StepResult when create fails."""
+
+    @patch(f"{_BASE_MODULE}._emit_and_log")
+    @patch(f"{_BASE_MODULE}.emit_artifact_comment")
+    @patch(f"{_BASE_MODULE}.log_artifact_comment_status")
+    @patch(f"{_BASE_MODULE}.subprocess.run")
+    @patch.dict("os.environ", {"GITLAB_PAT": "tok", "PATH": "/usr/bin"}, clear=True)
+    def test_non_zero_create_exit_returns_failed_step_result(
+        self,
+        mock_run: MagicMock,
+        _mock_log: MagicMock,
+        mock_emit_artifact: MagicMock,
+        mock_emit: MagicMock,
+        base_context: WorkflowContext,
+        store: ArtifactStore,
+    ) -> None:
+        """Non-zero glab mr create exit code results in a failed StepResult."""
+        store.write_artifact(
+            ComposeRequestArtifact(
+                workflow_id="test-glab-pr",
+                repos=[
+                    {
+                        "repo": "/path/to/repo",
+                        "title": "Test MR",
+                        "summary": "Summary",
+                        "commits": [],
+                    }
+                ],
+            )
+        )
+        mock_emit.return_value = ("success", "ok")
+        mock_emit_artifact.return_value = ("success", "ok")
+
+        def _side_effect(cmd: list[str], **_kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            if cmd[0] == "git" and cmd[1] == "rev-parse":
+                result.returncode = 0
+                result.stdout = "feature-branch"
+            elif cmd[0] == "glab" and cmd[1] == "mr" and cmd[2] == "list":
+                result.returncode = 0
+                result.stdout = "[]"
+            elif cmd[0] == "git" and cmd[1] == "push":
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+            elif cmd[0] == "glab" and cmd[1] == "mr" and cmd[2] == "create":
+                result.returncode = 1
+                result.stdout = ""
+                result.stderr = "glab: HTTP 422"
+            else:
+                result.returncode = 0
+                result.stdout = ""
+            return result
+
+        mock_run.side_effect = _side_effect
+
+        step = GlabPullRequestStep()
+        result = step.run(base_context)
+
+        assert result.success is False
+        assert result.error is not None
+        assert "creation failed for one or more repos" in result.error
+
+    @patch(f"{_BASE_MODULE}._emit_and_log")
+    @patch(f"{_BASE_MODULE}.emit_artifact_comment")
+    @patch(f"{_BASE_MODULE}.log_artifact_comment_status")
+    @patch(f"{_BASE_MODULE}.subprocess.run")
+    @patch.dict("os.environ", {"GITLAB_PAT": "tok", "PATH": "/usr/bin"}, clear=True)
+    def test_unparseable_create_output_returns_failed_step_result(
+        self,
+        mock_run: MagicMock,
+        _mock_log: MagicMock,
+        mock_emit_artifact: MagicMock,
+        mock_emit: MagicMock,
+        base_context: WorkflowContext,
+        store: ArtifactStore,
+    ) -> None:
+        """Successful exit but unparseable glab mr create output results in failed StepResult."""
+        store.write_artifact(
+            ComposeRequestArtifact(
+                workflow_id="test-glab-pr",
+                repos=[
+                    {
+                        "repo": "/path/to/repo",
+                        "title": "Test MR",
+                        "summary": "Summary",
+                        "commits": [],
+                    }
+                ],
+            )
+        )
+        mock_emit.return_value = ("success", "ok")
+        mock_emit_artifact.return_value = ("success", "ok")
+
+        def _side_effect(cmd: list[str], **_kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            if cmd[0] == "git" and cmd[1] == "rev-parse":
+                result.returncode = 0
+                result.stdout = "feature-branch"
+            elif cmd[0] == "glab" and cmd[1] == "mr" and cmd[2] == "list":
+                result.returncode = 0
+                result.stdout = "[]"
+            elif cmd[0] == "git" and cmd[1] == "push":
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+            elif cmd[0] == "glab" and cmd[1] == "mr" and cmd[2] == "create":
+                result.returncode = 0
+                result.stdout = "not a valid url\n"
+            else:
+                result.returncode = 0
+                result.stdout = ""
+            return result
+
+        mock_run.side_effect = _side_effect
+
+        step = GlabPullRequestStep()
+        result = step.run(base_context)
+
+        assert result.success is False
+        assert result.error is not None
+        assert "creation failed for one or more repos" in result.error
+
+    @patch(f"{_BASE_MODULE}._emit_and_log")
+    @patch(f"{_BASE_MODULE}.emit_artifact_comment")
+    @patch(f"{_BASE_MODULE}.log_artifact_comment_status")
+    @patch(f"{_BASE_MODULE}.subprocess.run")
+    @patch(f"{_BASE_MODULE}.get_affected_repo_paths")
+    @patch.dict("os.environ", {"GITLAB_PAT": "tok", "PATH": "/usr/bin"}, clear=True)
+    def test_multi_repo_first_success_second_failure(
+        self,
+        mock_get_affected: MagicMock,
+        mock_run: MagicMock,
+        _mock_log: MagicMock,
+        mock_emit_artifact: MagicMock,
+        mock_emit: MagicMock,
+        base_context: WorkflowContext,
+        store: ArtifactStore,
+    ) -> None:
+        """First repo succeeds (artifact written); second repo fails; run() returns failed."""
+        store.write_artifact(
+            ComposeRequestArtifact(
+                workflow_id="test-glab-pr",
+                repos=[
+                    {
+                        "repo": "/path/to/repo-a",
+                        "title": "MR A",
+                        "summary": "Summary A",
+                        "commits": [],
+                    },
+                    {
+                        "repo": "/path/to/repo-b",
+                        "title": "MR B",
+                        "summary": "Summary B",
+                        "commits": [],
+                    },
+                ],
+            )
+        )
+        mock_emit.return_value = ("success", "ok")
+        mock_emit_artifact.return_value = ("success", "ok")
+
+        base_context.repo_paths = ["/path/to/repo-a", "/path/to/repo-b"]
+        mock_get_affected.return_value = ["/path/to/repo-a", "/path/to/repo-b"]
+
+        def _side_effect(cmd: list[str], **kwargs: Any) -> MagicMock:
+            cwd = str(kwargs.get("cwd", ""))
+            result = MagicMock()
+            if cmd[0] == "git" and cmd[1] == "rev-parse":
+                result.returncode = 0
+                result.stdout = "feature-branch"
+            elif cmd[0] == "glab" and cmd[1] == "mr" and cmd[2] == "list":
+                result.returncode = 0
+                result.stdout = "[]"
+            elif cmd[0] == "git" and cmd[1] == "push":
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+            elif cmd[0] == "glab" and cmd[1] == "mr" and cmd[2] == "create":
+                if "repo-a" in cwd:
+                    result.returncode = 0
+                    result.stdout = "https://gitlab.com/org/repo-a/-/merge_requests/1"
+                else:
+                    result.returncode = 1
+                    result.stdout = ""
+                    result.stderr = "glab: HTTP 422"
+            else:
+                result.returncode = 0
+                result.stdout = ""
+            return result
+
+        mock_run.side_effect = _side_effect
+
+        step = GlabPullRequestStep()
+        result = step.run(base_context)
+
+        assert result.success is False
+        assert result.error is not None
+        assert "creation failed for one or more repos" in result.error
+
+        # First repo's MR should still have been written to the artifact
+        artifact = store.read_artifact("glab-pull-request")
+        assert len(artifact.pull_requests) == 1
+        assert artifact.pull_requests[0].url == "https://gitlab.com/org/repo-a/-/merge_requests/1"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -413,7 +413,7 @@ def test_create_pr_step_already_exists_is_success(mock_subprocess, mock_emit, mo
 @patch("rouge.core.workflow.pull_request_step_base.subprocess.run")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_gh_command_failure(mock_subprocess, mock_emit, mock_which) -> None:
-    """Test PR creation handles gh command failure."""
+    """Test PR creation surfaces gh command failure as a failed StepResult."""
 
     from rouge.core.workflow.steps.gh_pull_request_step import (
         GhPullRequestStep,
@@ -452,8 +452,10 @@ def test_create_pr_step_gh_command_failure(mock_subprocess, mock_emit, mock_whic
     step = GhPullRequestStep()
     result = step.run(context)
 
-    # When all repos fail (only one repo), step returns success (best-effort)
-    assert result.success is True
+    # Per-repo failures are surfaced as a failed StepResult so callers can react.
+    assert result.success is False
+    assert result.error is not None
+    assert "creation failed for one or more repos" in result.error
 
 
 @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
@@ -461,7 +463,7 @@ def test_create_pr_step_gh_command_failure(mock_subprocess, mock_emit, mock_whic
 @patch("rouge.core.workflow.pull_request_step_base.subprocess.run")
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_timeout(mock_subprocess, mock_emit, mock_which) -> None:
-    """Test PR creation handles timeout on gh pr create (caught per-repo, best-effort)."""
+    """Test PR creation surfaces a per-repo `gh pr create` timeout as a failed StepResult."""
     import subprocess
 
     from rouge.core.workflow.steps.gh_pull_request_step import (
@@ -500,8 +502,10 @@ def test_create_pr_step_timeout(mock_subprocess, mock_emit, mock_which) -> None:
     step = GhPullRequestStep()
     result = step.run(context)
 
-    # Per-repo timeout is caught in _process_repo; step returns success (best-effort)
-    assert result.success is True
+    # Per-repo timeout is caught in _process_repo and reported as a failed StepResult.
+    assert result.success is False
+    assert result.error is not None
+    assert "creation failed for one or more repos" in result.error
 
 
 @patch("rouge.core.workflow.steps.gh_pull_request_step.shutil.which")
@@ -727,7 +731,7 @@ def test_create_pr_step_multi_repo_success(mock_emit, mock_subprocess, mock_whic
 @patch.dict("os.environ", {"GITHUB_PAT": "test-token"})
 def test_create_pr_step_multi_repo_failure(mock_emit, mock_subprocess, mock_which) -> None:
     """Test PR creation with both repos failing: subprocess invoked once per repo,
-    best-effort continues."""
+    loop continues, and the step returns a failed StepResult."""
 
     from rouge.core.workflow.steps.gh_pull_request_step import GhPullRequestStep
 
@@ -781,8 +785,10 @@ def test_create_pr_step_multi_repo_failure(mock_emit, mock_subprocess, mock_whic
     step = GhPullRequestStep()
     result = step.run(context)
 
-    # Step is best-effort: returns success even when all repos fail
-    assert result.success is True
+    # All-repo failures surface as a failed StepResult; loop still continues over every repo.
+    assert result.success is False
+    assert result.error is not None
+    assert "creation failed for one or more repos" in result.error
     # Subprocess called 6 times per repo = 12 total (loop continues on per-repo failure)
     assert mock_subprocess.call_count == 12
 
@@ -978,7 +984,7 @@ def test_create_gitlab_mr_step_empty_title(mock_get_logger, mock_emit) -> None:
 def test_create_gitlab_mr_step_glab_command_failure(
     mock_subprocess, mock_get_logger, mock_emit
 ) -> None:
-    """Test MR creation handles glab command failure (best-effort: returns success)."""
+    """Test MR creation surfaces glab command failure as a failed StepResult."""
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
@@ -1019,8 +1025,10 @@ def test_create_gitlab_mr_step_glab_command_failure(
     step = GlabPullRequestStep()
     result = step.run(context)
 
-    # Per-repo failure continues loop; no MRs created → returns ok (best-effort step)
-    assert result.success is True
+    # Per-repo failure continues the loop; no MRs created → step returns a failed StepResult.
+    assert result.success is False
+    assert result.error is not None
+    assert "creation failed for one or more repos" in result.error
     mock_logger.warning.assert_called()
     mock_emit.assert_called_once()
     assert mock_emit.call_args[0][0].raw["output"] == "merge-request-failed"
@@ -1031,7 +1039,7 @@ def test_create_gitlab_mr_step_glab_command_failure(
 @patch("rouge.core.workflow.pull_request_step_base.subprocess.run")
 @patch.dict("os.environ", {"GITLAB_PAT": "test-token"})
 def test_create_gitlab_mr_step_timeout(mock_subprocess, mock_get_logger, mock_emit) -> None:
-    """Test MR creation handles timeout on glab mr create (caught per-repo, step continues)."""
+    """Test MR creation surfaces a per-repo `glab mr create` timeout as a failed StepResult."""
     import subprocess
 
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
@@ -1072,8 +1080,10 @@ def test_create_gitlab_mr_step_timeout(mock_subprocess, mock_get_logger, mock_em
     step = GlabPullRequestStep()
     result = step.run(context)
 
-    # Per-repo timeout is caught in the inner loop; step continues and returns success
-    assert result.success is True
+    # Per-repo timeout is caught in the inner loop and reported as a failed StepResult.
+    assert result.success is False
+    assert result.error is not None
+    assert "creation failed for one or more repos" in result.error
     mock_logger.warning.assert_called()
     mock_emit.assert_called_once()
     assert mock_emit.call_args[0][0].raw["output"] == "merge-request-failed"


### PR DESCRIPTION
## Description

PR/MR creation failures in `_process_repo` were previously swallowed — the step would log an error and continue, but ultimately return `StepResult.ok`. This change threads a typed return value (`bool | None`) from `_process_repo` through `_dispatch_repos` (now returning a `(dispatched_any, failed_any)` tuple) so that `_execute_pr_creation` can call `StepResult.fail` when any repo fails to create a PR/MR. Partial progress (repos that did succeed) is still persisted to the artifact store before the failure is surfaced.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- `_process_repo` return type changed from `None` to `bool | None`: returns `True` on success, `False` on creation failure, `None` for intentional skips (already-done, adopt-existing, no branch delta)
- `_dispatch_repos` return type changed from `bool` to `tuple[bool, bool]`; the second element `failed_any` is `True` if any dispatched repo returned `False`
- `_execute_pr_creation` unpacks the new tuple and calls `StepResult.fail` when `failed_any` is set
- Added `TestGhPullRequestStepFailure` (3 tests) covering non-zero `gh pr create` exit, unparseable output, and multi-repo partial-success
- Added `TestGlabPullRequestStepFailure` (3 tests) covering the same scenarios for `glab mr create`

## How to Test

- [ ] Run `pytest tests/test_gh_pull_request_step.py::TestGhPullRequestStepFailure` — all 3 tests should pass
- [ ] Run `pytest tests/test_glab_pull_request_step.py::TestGlabPullRequestStepFailure` — all 3 tests should pass
- [ ] Run the full test suite (`pytest`) to confirm no regressions