### PR TITLE
refactor(workflow): unify implement-direct artifact type to "implement"

### DIFF
--- a/src/rouge/core/workflow/step_registry.py
+++ b/src/rouge/core/workflow/step_registry.py
@@ -537,7 +537,7 @@ def _register_default_steps(registry: StepRegistry) -> None:
         ImplementDirectStep,
         slug="implement-direct",
         dependencies=["git-branch", "fetch-issue"],
-        outputs=["implement:direct"],
+        outputs=["implement"],
         is_critical=True,
         description="Implement directly from the issue description without a plan",
         dependency_kinds={"git-branch": "ordering-only"},

--- a/src/rouge/core/workflow/steps/implement_direct_step.py
+++ b/src/rouge/core/workflow/steps/implement_direct_step.py
@@ -13,7 +13,7 @@ from rouge.core.notifications.comments import (
 from rouge.core.utils import get_logger
 from rouge.core.workflow.artifacts import (
     FetchIssueArtifact,
-    ImplementDirectArtifact,
+    ImplementArtifact,
 )
 from rouge.core.workflow.shared import AGENT_PLAN_IMPLEMENTOR
 from rouge.core.workflow.step_base import StepInputError, WorkflowContext, WorkflowStep
@@ -151,7 +151,7 @@ class ImplementDirectStep(WorkflowStep):
         context.data["implement_data"] = implement_response.data
 
         # Save artifact
-        artifact = ImplementDirectArtifact(
+        artifact = ImplementArtifact(
             workflow_id=context.adw_id,
             implement_data=implement_response.data,
         )

--- a/tests/test_implement_step.py
+++ b/tests/test_implement_step.py
@@ -462,5 +462,5 @@ class TestImplementDirectStepRun:
         direct_mock_context.artifact_store.write_artifact.assert_called_once()
 
         saved_artifact = direct_mock_context.artifact_store.write_artifact.call_args[0][0]
-        assert saved_artifact.artifact_type == "implement:direct"
+        assert saved_artifact.artifact_type == "implement"
         assert saved_artifact.implement_data == sample_data

--- a/tests/test_step_registry.py
+++ b/tests/test_step_registry.py
@@ -718,7 +718,7 @@ class TestGlobalRegistry:
             metadata is not None
         ), "ImplementDirectStep should be registered with slug 'implement-direct'"
         assert metadata.dependencies == ["git-branch", "fetch-issue"]
-        assert metadata.outputs == ["implement:direct"]
+        assert metadata.outputs == ["implement"]
         assert metadata.dependency_kinds == {"git-branch": "ordering-only"}
         assert metadata.is_critical is True
 


### PR DESCRIPTION
## Description

Renames the `ImplementDirectArtifact` to `ImplementArtifact` and updates the output tag from `"implement:direct"` to `"implement"` to align with the shared artifact naming convention used elsewhere in the workflow system.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Replaced `ImplementDirectArtifact` with `ImplementArtifact` in `implement_direct_step.py`
- Updated the `outputs` registration from `["implement:direct"]` to `["implement"]` in `step_registry.py`
- Updated test assertions in `test_implement_step.py` and `test_step_registry.py` to match the new artifact type

## How to Test

- [ ] Run `pytest tests/test_implement_step.py` and confirm all assertions pass
- [ ] Run `pytest tests/test_step_registry.py` and confirm `ImplementDirectStep` output metadata resolves to `"implement"`