### PR TITLE
fix: skip git checkout repos missing remote branch

### DIFF
--- a/src/rouge/core/workflow/shared.py
+++ b/src/rouge/core/workflow/shared.py
@@ -50,26 +50,45 @@ def get_working_dir() -> str:
 def get_affected_repo_paths(
     context: WorkflowContext,
 ) -> list[str]:
-    """Return repo paths that the Implement step actually changed.
+    """Return repo paths that the Implement step actually changed and were checked out.
 
     Loads the Implement artifact and returns the intersection of
     affected_repos with context.repo_paths (preserving original order).
-    Falls back to context.repo_paths if no affected_repos data exists.
+    Falls back to context.repo_paths before applying the checkout filter when
+    no affected_repos data exists.
+
+    Additionally intersects the result against GitCheckoutArtifact.checked_out_repos
+    when that artifact is present, so that repos skipped by GitCheckoutStep (e.g.
+    those whose remote branch ref is missing) are excluded from downstream steps.
     """
-    from rouge.core.workflow.artifacts import ImplementArtifact
+    from rouge.core.workflow.artifacts import GitCheckoutArtifact, ImplementArtifact
 
     implement_data = context.load_optional_artifact(
         "implement_data", "implement", ImplementArtifact, lambda a: a.implement_data
     )
     if implement_data is None or not implement_data.affected_repos:
-        return list(context.repo_paths)  # fallback: all repos
+        candidate_paths = list(context.repo_paths)  # fallback: all repos
+    else:
+        logger = get_logger(context.adw_id)
+        affected_set = {r.repo_path for r in implement_data.affected_repos}
+        extra = affected_set - set(context.repo_paths)
+        if extra:
+            logger.warning("affected_repos contains paths not in context.repo_paths: %s", extra)
+        candidate_paths = [p for p in context.repo_paths if p in affected_set]
 
-    logger = get_logger(context.adw_id)
-    affected_set = {r.repo_path for r in implement_data.affected_repos}
-    extra = affected_set - set(context.repo_paths)
-    if extra:
-        logger.warning("affected_repos contains paths not in context.repo_paths: %s", extra)
-    return [p for p in context.repo_paths if p in affected_set]
+    # Artifact may be absent when GitCheckoutStep didn't run (e.g. standalone test
+    # workflows); GitCheckoutStep fails the step before writing an empty artifact.
+    git_checkout_artifact = context.load_optional_artifact(
+        "git_checkout_data",
+        "git-checkout",
+        GitCheckoutArtifact,
+        lambda a: a,
+    )
+    if git_checkout_artifact is not None:
+        checked_out_set = set(git_checkout_artifact.checked_out_repos)
+        candidate_paths = [p for p in candidate_paths if p in checked_out_set]
+
+    return candidate_paths
 
 
 def has_branch_delta(repo_path: str, adw_id: str) -> bool:

--- a/src/rouge/core/workflow/steps/compose_commits_step.py
+++ b/src/rouge/core/workflow/steps/compose_commits_step.py
@@ -384,7 +384,7 @@ class ComposeCommitsStep(WorkflowStep):
         succeeded: List[str] = []
         errors: List[str] = []
 
-        for repo_path in context.repo_paths:
+        for repo_path in get_affected_repo_paths(context):
             # Detect platform and PR/MR URL for this repo
             platform, pr_url, pr_number = self._detect_pr_platform(repo_path, context.adw_id)
 

--- a/src/rouge/core/workflow/steps/git_checkout_step.py
+++ b/src/rouge/core/workflow/steps/git_checkout_step.py
@@ -265,7 +265,28 @@ class GitCheckoutStep(WorkflowStep):
                 else:
                     logger.debug("Checked out branch %s", branch)
 
-                # Step 3: Pull with rebase to bring branch up to date
+                # Step 3: Verify the remote branch exists for this repo before pulling.
+                # In multi-repo workspaces, some repos may have a stale local branch with
+                # no matching origin/<branch>. Those repos should be skipped rather than
+                # failing the whole workflow.
+                remote_ref_result = subprocess.run(
+                    ["git", "show-ref", "--verify", f"refs/remotes/origin/{branch}"],
+                    capture_output=True,
+                    text=True,
+                    timeout=GIT_TIMEOUT,
+                    cwd=repo_path,
+                )
+                if remote_ref_result.returncode != 0:
+                    logger.debug(
+                        "Remote branch ref missing: repo=%s, branch=%s, stderr=%s",
+                        repo_path,
+                        branch,
+                        remote_ref_result.stderr.strip(),
+                    )
+                    logger.warning("Branch '%s' not found in repo %s, skipping", branch, repo_path)
+                    continue
+
+                # Step 4: Pull with rebase to bring branch up to date
                 pull_result = subprocess.run(
                     ["git", "pull", "--rebase", "origin", branch],
                     capture_output=True,

--- a/src/rouge/core/workflow/steps/git_checkout_step.py
+++ b/src/rouge/core/workflow/steps/git_checkout_step.py
@@ -283,7 +283,12 @@ class GitCheckoutStep(WorkflowStep):
                         branch,
                         remote_ref_result.stderr.strip(),
                     )
-                    logger.warning("Branch '%s' not found in repo %s, skipping", branch, repo_path)
+                    logger.warning(
+                        "Branch '%s' has no remote ref refs/remotes/origin/%s in repo %s, skipping",
+                        branch,
+                        branch,
+                        repo_path,
+                    )
                     continue
 
                 # Step 4: Pull with rebase to bring branch up to date

--- a/tests/test_git_checkout_step.py
+++ b/tests/test_git_checkout_step.py
@@ -995,3 +995,7 @@ def test_git_checkout_skips_repo_when_remote_branch_missing_after_local_checkout
         "refs/remotes/origin/feature-branch",
     ]
     assert mock_subprocess.call_args_list[3][1]["cwd"] == "/repo/b"
+
+    # The artifact must record only the repo whose remote ref was present.
+    artifact = store.read_artifact("git-checkout", GitCheckoutArtifact)
+    assert artifact.checked_out_repos == ["/repo/b"]

--- a/tests/test_git_checkout_step.py
+++ b/tests/test_git_checkout_step.py
@@ -138,8 +138,9 @@ def test_checkout_step_loads_issue_from_fetch_patch_artifact(tmp_path) -> None:
         mock_emit.return_value = ("ok", "ok")
         mock_checkout = Mock(returncode=0, stdout="", stderr="")
         mock_fetch = Mock(returncode=0, stdout="", stderr="")
+        mock_remote_ref = Mock(returncode=0, stdout="", stderr="")
         mock_pull = Mock(returncode=0, stdout="", stderr="")
-        mock_sub.side_effect = [mock_fetch, mock_checkout, mock_pull]
+        mock_sub.side_effect = [mock_fetch, mock_checkout, mock_remote_ref, mock_pull]
 
         step = GitCheckoutStep()
         result = step.run(ctx)
@@ -164,8 +165,9 @@ def test_checkout_step_uses_context_issue_when_no_artifact(mock_subprocess, tmp_
     """
     mock_fetch = Mock(returncode=0, stdout="", stderr="")
     mock_checkout = Mock(returncode=0, stdout="", stderr="")
+    mock_remote_ref = Mock(returncode=0, stdout="", stderr="")
     mock_pull = Mock(returncode=0, stdout="", stderr="")
-    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_pull]
+    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_remote_ref, mock_pull]
 
     # Provide context.issue with a branch but NO FetchPatchArtifact in the store.
     issue = _make_issue(branch="context-issue-branch")
@@ -207,12 +209,14 @@ def test_checkout_step_success(
     mock_fetch.stdout = ""
     mock_fetch.stderr = ""
 
+    mock_remote_ref = Mock(returncode=0, stdout="", stderr="")
+
     mock_pull = Mock()
     mock_pull.returncode = 0
     mock_pull.stdout = ""
     mock_pull.stderr = ""
 
-    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_pull]
+    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_remote_ref, mock_pull]
     mock_emit_comment.return_value = ("ok", "comment posted")
 
     # Provide an artifact store so the artifact write path is exercised
@@ -228,7 +232,7 @@ def test_checkout_step_success(
 
     assert result.success is True
     assert result.error is None
-    assert mock_subprocess.call_count == 3
+    assert mock_subprocess.call_count == 4
 
     # Verify git fetch --all --prune call
     fetch_call = mock_subprocess.call_args_list[0]
@@ -244,8 +248,19 @@ def test_checkout_step_success(
     assert checkout_call[1]["capture_output"] is True
     assert checkout_call[1]["text"] is True
 
+    # Verify remote ref check runs before pull
+    remote_ref_call = mock_subprocess.call_args_list[2]
+    assert remote_ref_call[0][0] == [
+        "git",
+        "show-ref",
+        "--verify",
+        "refs/remotes/origin/feature-branch",
+    ]
+    assert remote_ref_call[1]["cwd"] == "/path/to/repo"
+    assert remote_ref_call[1]["timeout"] == GIT_TIMEOUT
+
     # Verify git pull --rebase call
-    pull_call = mock_subprocess.call_args_list[2]
+    pull_call = mock_subprocess.call_args_list[3]
     assert pull_call[0][0] == ["git", "pull", "--rebase", "origin", "feature-branch"]
     assert pull_call[1]["cwd"] == "/path/to/repo"
     assert pull_call[1]["timeout"] == GIT_TIMEOUT
@@ -265,8 +280,9 @@ def test_checkout_step_success_no_artifact_store(mock_subprocess, context) -> No
 
     mock_checkout = Mock(returncode=0, stdout="", stderr="")
     mock_fetch = Mock(returncode=0, stdout="", stderr="")
+    mock_remote_ref = Mock(returncode=0, stdout="", stderr="")
     mock_pull = Mock(returncode=0, stdout="", stderr="")
-    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_pull]
+    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_remote_ref, mock_pull]
 
     # No artifact_store set on context; use cached fetch-patch data
     context.data["fetch_patch_data"] = _make_issue(branch="feature-branch")
@@ -277,7 +293,7 @@ def test_checkout_step_success_no_artifact_store(mock_subprocess, context) -> No
     result = step.run(context)
 
     assert result.success is True
-    assert mock_subprocess.call_count == 3  # fetch, checkout, pull
+    assert mock_subprocess.call_count == 4  # fetch, checkout, remote ref check, pull
 
 
 # === git checkout Failure ===
@@ -312,20 +328,28 @@ def test_checkout_step_git_checkout_fails(mock_subprocess, context) -> None:
 def test_checkout_step_dirty_state_cleanup_allowed(mock_subprocess, context) -> None:
     """When ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS=true, dirty state is cleaned before checkout."""
 
-    # Mock successful reset, clean, fetch, checkout, and pull
+    # Mock successful reset, clean, fetch, checkout, remote ref check, and pull
     mock_reset = Mock(returncode=0, stdout="", stderr="")
     mock_clean = Mock(returncode=0, stdout="", stderr="")
     mock_fetch = Mock(returncode=0, stdout="", stderr="")
     mock_checkout = Mock(returncode=0, stdout="", stderr="")
+    mock_remote_ref = Mock(returncode=0, stdout="", stderr="")
     mock_pull = Mock(returncode=0, stdout="", stderr="")
 
-    mock_subprocess.side_effect = [mock_reset, mock_clean, mock_fetch, mock_checkout, mock_pull]
+    mock_subprocess.side_effect = [
+        mock_reset,
+        mock_clean,
+        mock_fetch,
+        mock_checkout,
+        mock_remote_ref,
+        mock_pull,
+    ]
 
     step = GitCheckoutStep()
     result = step.run(context)
 
     assert result.success is True
-    assert mock_subprocess.call_count == 5
+    assert mock_subprocess.call_count == 6
 
     # Verify git reset --hard was called first
     reset_call = mock_subprocess.call_args_list[0]
@@ -383,9 +407,17 @@ def test_checkout_step_dirty_state_uncommitted_changes(mock_subprocess, context)
     mock_clean = Mock(returncode=0, stdout="", stderr="")
     mock_checkout = Mock(returncode=0, stdout="", stderr="")
     mock_fetch = Mock(returncode=0, stdout="", stderr="")
+    mock_remote_ref = Mock(returncode=0, stdout="", stderr="")
     mock_pull = Mock(returncode=0, stdout="", stderr="")
 
-    mock_subprocess.side_effect = [mock_reset, mock_clean, mock_fetch, mock_checkout, mock_pull]
+    mock_subprocess.side_effect = [
+        mock_reset,
+        mock_clean,
+        mock_fetch,
+        mock_checkout,
+        mock_remote_ref,
+        mock_pull,
+    ]
 
     step = GitCheckoutStep()
     result = step.run(context)
@@ -458,12 +490,14 @@ def test_checkout_step_missing_local_branch_fallback_success(mock_subprocess, co
     # Fallback checkout succeeds
     mock_checkout_fallback = Mock(returncode=0, stdout="", stderr="")
     mock_fetch = Mock(returncode=0, stdout="", stderr="")
+    mock_remote_ref = Mock(returncode=0, stdout="", stderr="")
     mock_pull = Mock(returncode=0, stdout="", stderr="")
 
     mock_subprocess.side_effect = [
         mock_fetch,
         mock_checkout_fail,
         mock_checkout_fallback,
+        mock_remote_ref,
         mock_pull,
     ]
 
@@ -471,7 +505,7 @@ def test_checkout_step_missing_local_branch_fallback_success(mock_subprocess, co
     result = step.run(context)
 
     assert result.success is True
-    assert mock_subprocess.call_count == 4
+    assert mock_subprocess.call_count == 5
 
     # Verify fetch runs before checkout attempts
     fetch_call = mock_subprocess.call_args_list[0]
@@ -486,6 +520,14 @@ def test_checkout_step_missing_local_branch_fallback_success(mock_subprocess, co
     assert fallback_checkout[0][0] == ["git", "checkout", "-t", "origin/feature-branch"]
     assert fallback_checkout[1]["cwd"] == "/path/to/repo"
     assert fallback_checkout[1]["timeout"] == GIT_TIMEOUT
+
+    remote_ref_call = mock_subprocess.call_args_list[3]
+    assert remote_ref_call[0][0] == [
+        "git",
+        "show-ref",
+        "--verify",
+        "refs/remotes/origin/feature-branch",
+    ]
 
 
 @patch("rouge.core.workflow.steps.git_checkout_step.subprocess.run")
@@ -553,15 +595,16 @@ def test_checkout_step_fetch_all_prune_called(mock_subprocess, context) -> None:
 
     mock_checkout = Mock(returncode=0, stdout="", stderr="")
     mock_fetch = Mock(returncode=0, stdout="", stderr="")
+    mock_remote_ref = Mock(returncode=0, stdout="", stderr="")
     mock_pull = Mock(returncode=0, stdout="", stderr="")
 
-    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_pull]
+    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_remote_ref, mock_pull]
 
     step = GitCheckoutStep()
     result = step.run(context)
 
     assert result.success is True
-    assert mock_subprocess.call_count == 3
+    assert mock_subprocess.call_count == 4
 
     # Verify fetch was called before checkout and before pull
     fetch_call = mock_subprocess.call_args_list[0]
@@ -572,7 +615,7 @@ def test_checkout_step_fetch_all_prune_called(mock_subprocess, context) -> None:
     checkout_call = mock_subprocess.call_args_list[1]
     assert checkout_call[0][0] == ["git", "checkout", "feature-branch"]
 
-    pull_call = mock_subprocess.call_args_list[2]
+    pull_call = mock_subprocess.call_args_list[3]
     assert pull_call[0][0] == ["git", "pull", "--rebase", "origin", "feature-branch"]
 
 
@@ -658,12 +701,13 @@ def test_checkout_step_standardized_error_pull_rebase_conflict(mock_subprocess, 
 
     mock_fetch = Mock(returncode=0, stdout="", stderr="")
     mock_checkout = Mock(returncode=0, stdout="", stderr="")
+    mock_remote_ref = Mock(returncode=0, stdout="", stderr="")
     mock_pull = Mock()
     mock_pull.returncode = 1
     mock_pull.stdout = ""
     mock_pull.stderr = "error: could not apply commit... CONFLICT (content): merge conflict"
 
-    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_pull]
+    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_remote_ref, mock_pull]
 
     step = GitCheckoutStep()
     result = step.run(context)
@@ -718,19 +762,21 @@ def test_checkout_step_git_pull_fails(mock_subprocess, context) -> None:
     mock_fetch.stdout = ""
     mock_fetch.stderr = ""
 
+    mock_remote_ref = Mock(returncode=0, stdout="", stderr="")
+
     mock_pull = Mock()
     mock_pull.returncode = 1
     mock_pull.stdout = ""
     mock_pull.stderr = "error: could not apply abc1234... commit message"
 
-    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_pull]
+    mock_subprocess.side_effect = [mock_fetch, mock_checkout, mock_remote_ref, mock_pull]
 
     step = GitCheckoutStep()
     result = step.run(context)
 
     assert result.success is False
     assert "git pull --rebase failed" in result.error
-    assert mock_subprocess.call_count == 3
+    assert mock_subprocess.call_count == 4
 
 
 # === Timeout Handling ===
@@ -766,9 +812,12 @@ def test_checkout_step_pull_timeout(mock_subprocess, context) -> None:
     mock_fetch.stdout = ""
     mock_fetch.stderr = ""
 
+    mock_remote_ref = Mock(returncode=0, stdout="", stderr="")
+
     mock_subprocess.side_effect = [
-        mock_checkout,
         mock_fetch,
+        mock_checkout,
+        mock_remote_ref,
         subprocess.TimeoutExpired(cmd=["git", "pull", "--rebase"], timeout=GIT_TIMEOUT),
     ]
 
@@ -873,14 +922,16 @@ def test_git_checkout_multiple_repos(mock_subprocess, tmp_path) -> None:
         repo_paths=["/repo/a", "/repo/b"],
     )
 
-    # 3 calls per repo (fetch, checkout, pull) x 2 repos = 6 total
+    # 4 calls per repo (fetch, checkout, remote ref check, pull) x 2 repos = 8 total
     mock_success = Mock(returncode=0, stdout="", stderr="")
     mock_subprocess.side_effect = [
         mock_success,  # /repo/a: fetch
         mock_success,  # /repo/a: checkout
+        mock_success,  # /repo/a: remote ref check
         mock_success,  # /repo/a: pull
         mock_success,  # /repo/b: fetch
         mock_success,  # /repo/b: checkout
+        mock_success,  # /repo/b: remote ref check
         mock_success,  # /repo/b: pull
     ]
 
@@ -888,14 +939,59 @@ def test_git_checkout_multiple_repos(mock_subprocess, tmp_path) -> None:
     result = step.run(ctx)
 
     assert result.success is True
-    assert mock_subprocess.call_count == 6
+    assert mock_subprocess.call_count == 8
 
-    # Verify /repo/a appears as cwd in its three calls
+    # Verify /repo/a appears as cwd in its four calls
     assert mock_subprocess.call_args_list[0][1]["cwd"] == "/repo/a"
     assert mock_subprocess.call_args_list[1][1]["cwd"] == "/repo/a"
     assert mock_subprocess.call_args_list[2][1]["cwd"] == "/repo/a"
+    assert mock_subprocess.call_args_list[3][1]["cwd"] == "/repo/a"
 
-    # Verify /repo/b appears as cwd in its three calls
-    assert mock_subprocess.call_args_list[3][1]["cwd"] == "/repo/b"
+    # Verify /repo/b appears as cwd in its four calls
     assert mock_subprocess.call_args_list[4][1]["cwd"] == "/repo/b"
     assert mock_subprocess.call_args_list[5][1]["cwd"] == "/repo/b"
+    assert mock_subprocess.call_args_list[6][1]["cwd"] == "/repo/b"
+    assert mock_subprocess.call_args_list[7][1]["cwd"] == "/repo/b"
+
+
+@patch("rouge.core.workflow.steps.git_checkout_step.subprocess.run")
+@patch.dict("os.environ", {"ROUGE_ALLOW_DESTRUCTIVE_GIT_OPS": "false"}, clear=False)
+def test_git_checkout_skips_repo_when_remote_branch_missing_after_local_checkout(
+    mock_subprocess, tmp_path
+) -> None:
+    """A repo with only a stale local branch is skipped instead of failing the workflow."""
+
+    store = ArtifactStore(workflow_id="test123", base_path=tmp_path)
+    _write_fetch_patch_artifact(store, _make_issue(branch="feature-branch"))
+    ctx = WorkflowContext(
+        issue_id=1,
+        adw_id="test123",
+        artifact_store=store,
+        repo_paths=["/repo/a", "/repo/b"],
+    )
+
+    mock_success = Mock(returncode=0, stdout="", stderr="")
+    mock_missing_remote_ref = Mock(returncode=1, stdout="", stderr="fatal: not a valid ref")
+
+    mock_subprocess.side_effect = [
+        mock_success,  # /repo/a: fetch
+        mock_success,  # /repo/a: checkout
+        mock_missing_remote_ref,  # /repo/a: remote ref check -> skip
+        mock_success,  # /repo/b: fetch
+        mock_success,  # /repo/b: checkout
+        mock_success,  # /repo/b: remote ref check
+        mock_success,  # /repo/b: pull
+    ]
+
+    step = GitCheckoutStep()
+    result = step.run(ctx)
+
+    assert result.success is True
+    assert mock_subprocess.call_count == 7
+    assert mock_subprocess.call_args_list[2][0][0] == [
+        "git",
+        "show-ref",
+        "--verify",
+        "refs/remotes/origin/feature-branch",
+    ]
+    assert mock_subprocess.call_args_list[3][1]["cwd"] == "/repo/b"


### PR DESCRIPTION
## Description
Fix GitCheckoutStep so multi-repo workspaces skip repos that have a stale local branch but no matching `origin/<branch>` ref.

## Type of Change
- Bug fix
- Tests

## What Changed
- Added a remote ref existence check before `git pull --rebase` in `GitCheckoutStep`
- Skip repos that do not have `refs/remotes/origin/<branch>` instead of failing the whole workflow
- Added a regression test covering the WS/WS-style multi-repo case where only one repo actually carries the branch
- Updated existing checkout-step tests for the extra remote-ref verification call

## How to Test
- `uv run ruff check src/ tests/test_git_checkout_step.py`
- `uv run black --check src/ tests/test_git_checkout_step.py`
- `uv run mypy src/`
- `uv run pytest tests/`