### PR TITLE
fix(adw): harden PR/MR criticality and relocate dotenv loading to entrypoint

### DIFF
--- a/src/rouge/adw/cli.py
+++ b/src/rouge/adw/cli.py
@@ -1,12 +1,26 @@
 """CLI interface for Rouge ADW."""
 
+from pathlib import Path
 from typing import Optional
 
 import typer
 
-from rouge.adw.adw import execute_adw_workflow
-from rouge.cli.utils import prepare_adw_id, validate_issue_id
-from rouge.core.utils import get_logger, setup_logger
+from rouge.core.database import init_db_env
+
+# Load environment variables
+env_file_path = Path.cwd() / ".env"
+if env_file_path.exists():
+    init_db_env(dotenv_path=env_file_path)
+else:
+    parent_env_file_path = Path.cwd().parent / ".env"
+    if parent_env_file_path.exists():
+        init_db_env(dotenv_path=parent_env_file_path)
+    else:
+        init_db_env()
+
+from rouge.adw.adw import execute_adw_workflow  # noqa: E402
+from rouge.cli.utils import prepare_adw_id, validate_issue_id  # noqa: E402
+from rouge.core.utils import get_logger, setup_logger  # noqa: E402
 
 app = typer.Typer(
     help="Rouge ADW - Agent Development Workflow",

--- a/src/rouge/core/__init__.py
+++ b/src/rouge/core/__init__.py
@@ -1,6 +1,6 @@
 """Shared infrastructure used by Rouge tooling (CLI, ADW, worker)."""
 
-from . import agent, database, models, paths, utils, workflow
+from . import database, models, paths, utils, workflow
 
 __all__ = [
     "database",
@@ -8,5 +8,4 @@ __all__ = [
     "paths",
     "utils",
     "workflow",
-    "agent",
 ]

--- a/src/rouge/core/agents/claude/claude.py
+++ b/src/rouge/core/agents/claude/claude.py
@@ -12,16 +12,11 @@ import subprocess
 from pathlib import Path
 from typing import Dict, Optional
 
-from dotenv import load_dotenv
-
 from rouge.core.agents.base import (
     AgentExecuteRequest,
     AgentExecuteResponse,
     CodingAgent,
 )
-
-# Load environment variables
-load_dotenv()
 
 # Get Claude Code CLI path from environment
 CLAUDE_PATH = os.getenv("CLAUDE_CODE_PATH", "claude")

--- a/src/rouge/core/workflow/pull_request_step_base.py
+++ b/src/rouge/core/workflow/pull_request_step_base.py
@@ -97,8 +97,9 @@ class PullRequestStepBase(WorkflowStep, ABC):
 
     @property
     def is_critical(self) -> bool:
-        # PR/MR creation is best-effort - workflow continues on failure
-        return False
+        # PR/MR creation is critical — attempted-and-failed creates abort the workflow;
+        # intentional skips remain non-failing via StepResult.ok.
+        return True
 
     # ------------------------------------------------------------------
     # Concrete methods – shared orchestration

--- a/tests/test_adw.py
+++ b/tests/test_adw.py
@@ -1,6 +1,10 @@
 """Tests for CAPE ADW functionality."""
 
+import importlib
+import os
+
 import pytest
+from typer.testing import CliRunner
 
 from rouge.adw.adw import execute_adw_workflow
 
@@ -97,3 +101,41 @@ def test_execute_adw_workflow_unknown_type_raises(monkeypatch) -> None:
 
     with pytest.raises(ValueError, match="Unknown workflow type 'bogus'"):
         execute_adw_workflow("test-adw-id", 999, workflow_type="bogus")
+
+
+def test_rouge_adw_loads_workspace_dotenv_before_workflow_runs(tmp_path, monkeypatch) -> None:
+    """Invoking rouge-adw from a workspace cwd must apply that workspace's .env.
+
+    Phase 1 moved dotenv loading to the top of ``rouge.adw.cli``.  This locks in
+    the contract that ``DEV_SEC_OPS_PLATFORM`` (and any other workspace
+    overrides) are visible by the time ``execute_adw_workflow`` is called.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".env").write_text("DEV_SEC_OPS_PLATFORM=gitlab\n")
+
+    # Clear any inherited platform value so the .env load is the only source.
+    monkeypatch.delenv("DEV_SEC_OPS_PLATFORM", raising=False)
+
+    # Re-import the ADW CLI module from the workspace cwd so the module-top
+    # env probe runs against the workspace .env.
+    monkeypatch.chdir(workspace)
+    import rouge.adw.cli as adw_cli
+
+    adw_cli = importlib.reload(adw_cli)
+
+    captured: dict[str, str | None] = {}
+
+    def fake_execute(adw_id, issue_id, *, workflow_type="full", resume_from=None):
+        captured["DEV_SEC_OPS_PLATFORM"] = os.environ.get("DEV_SEC_OPS_PLATFORM")
+        return True, adw_id
+
+    monkeypatch.setattr(adw_cli, "execute_adw_workflow", fake_execute)
+    # Avoid touching real logger files during the test.
+    monkeypatch.setattr(adw_cli, "setup_logger", lambda _wf_id: None)
+
+    runner = CliRunner()
+    result = runner.invoke(adw_cli.app, ["--adw-id", "test-adw", "42"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["DEV_SEC_OPS_PLATFORM"] == "gitlab"

--- a/tests/test_gh_pull_request_step.py
+++ b/tests/test_gh_pull_request_step.py
@@ -814,9 +814,9 @@ class TestGhPullRequestStepAttachment:
         # No attachment-related calls: no comment listing, no gh pr comment, no gh api PATCH
         for c in mock_subprocess.call_args_list:
             cmd_str = " ".join(c[0][0])
-            assert not ("api" in cmd_str and "/issues/" in cmd_str and "/comments" in cmd_str), (
-                "GitHub issue-comments API should not be called when attachment is None"
-            )
+            assert not (
+                "api" in cmd_str and "/issues/" in cmd_str and "/comments" in cmd_str
+            ), "GitHub issue-comments API should not be called when attachment is None"
             has_attachment_comment = (
                 "pr" in cmd_str and "comment" in cmd_str and "review-context" in cmd_str
             )

--- a/tests/test_glab_pull_request_step.py
+++ b/tests/test_glab_pull_request_step.py
@@ -87,9 +87,9 @@ def _find_glab_create_cmd(mock_run: MagicMock) -> list[str]:
         for call in mock_run.call_args_list
         if call[0][0][0] == "glab" and call[0][0][2] == "create"
     ]
-    assert len(glab_create_calls) == 1, (
-        f"Expected exactly 1 glab mr create call, got {len(glab_create_calls)}"
-    )
+    assert (
+        len(glab_create_calls) == 1
+    ), f"Expected exactly 1 glab mr create call, got {len(glab_create_calls)}"
     return glab_create_calls[0][0][0]
 
 
@@ -675,9 +675,9 @@ class TestGlabPullRequestStepAttachment:
         # No attachment-related calls: no notes listing, no note create, no api PUT
         for c in mock_subprocess.call_args_list:
             cmd_str = " ".join(c[0][0])
-            assert not ("api" in cmd_str and "notes" in cmd_str), (
-                "glab api notes listing should not be called when attachment is None"
-            )
+            assert not (
+                "api" in cmd_str and "notes" in cmd_str
+            ), "glab api notes listing should not be called when attachment is None"
             has_note_cmd = (
                 "glab" in cmd_str and "mr" in cmd_str and "note" in cmd_str and "api" not in cmd_str
             )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -800,14 +800,44 @@ def test_create_pr_step_multi_repo_failure(mock_emit, mock_subprocess, mock_whic
     assert push_call_b[1]["cwd"] == "/repo/b"
 
 
-def test_create_pr_step_is_not_critical() -> None:
-    """Test GhPullRequestStep is not critical."""
+def test_create_pr_step_is_critical() -> None:
+    """Test GhPullRequestStep is critical — failed PR creates abort the workflow."""
     from rouge.core.workflow.steps.gh_pull_request_step import (
         GhPullRequestStep,
     )
 
     step = GhPullRequestStep()
-    assert step.is_critical is False
+    assert step.is_critical is True
+
+
+def test_pr_step_failure_aborts_workflow(caplog, tmp_path) -> None:
+    """A failed GhPullRequestStep aborts the WorkflowRunner with no success log."""
+    import logging
+
+    from rouge.core.workflow.pipeline import WorkflowRunner
+    from rouge.core.workflow.steps.gh_pull_request_step import GhPullRequestStep
+
+    failing_pr_step = GhPullRequestStep()
+    pr_run = Mock(return_value=StepResult.fail("PR creation failed for one or more repos"))
+    # Patch the run method while preserving the critical property.
+    failing_pr_step.run = pr_run  # type: ignore[method-assign]
+
+    trailing_step = Mock()
+    trailing_step.name = "Trailing Step"
+    trailing_step.is_critical = True
+    trailing_step.run = Mock(return_value=StepResult.ok(None))
+
+    runner = WorkflowRunner([failing_pr_step, trailing_step])
+
+    with caplog.at_level(logging.INFO):
+        with patch("rouge.core.paths.get_working_dir", return_value=str(tmp_path)):
+            success = runner.run(issue_id=1, adw_id="adw-pr-fail")
+
+    assert success is False
+    # Trailing step must not execute after a critical PR failure.
+    trailing_step.run.assert_not_called()
+    assert "Workflow completed successfully" not in caplog.text
+    assert "Critical step 'Creating GitHub pull request' failed" in caplog.text
 
 
 def test_create_pr_step_name() -> None:
@@ -1233,12 +1263,42 @@ def test_create_gitlab_mr_step_push_timeout_continues_to_mr(mock_subprocess, moc
     assert mock_emit.call_args[0][0].raw["output"] == "merge-request-created"
 
 
-def test_create_gitlab_mr_step_is_not_critical() -> None:
-    """Test GlabPullRequestStep is not critical."""
+def test_create_gitlab_mr_step_is_critical() -> None:
+    """Test GlabPullRequestStep is critical — failed MR creates abort the workflow."""
     from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
 
     step = GlabPullRequestStep()
-    assert step.is_critical is False
+    assert step.is_critical is True
+
+
+def test_mr_step_failure_aborts_workflow(caplog, tmp_path) -> None:
+    """A failed GlabPullRequestStep aborts the WorkflowRunner with no success log."""
+    import logging
+
+    from rouge.core.workflow.pipeline import WorkflowRunner
+    from rouge.core.workflow.steps.glab_pull_request_step import GlabPullRequestStep
+
+    failing_mr_step = GlabPullRequestStep()
+    mr_run = Mock(return_value=StepResult.fail("MR creation failed for one or more repos"))
+    # Patch the run method while preserving the critical property.
+    failing_mr_step.run = mr_run  # type: ignore[method-assign]
+
+    trailing_step = Mock()
+    trailing_step.name = "Trailing Step"
+    trailing_step.is_critical = True
+    trailing_step.run = Mock(return_value=StepResult.ok(None))
+
+    runner = WorkflowRunner([failing_mr_step, trailing_step])
+
+    with caplog.at_level(logging.INFO):
+        with patch("rouge.core.paths.get_working_dir", return_value=str(tmp_path)):
+            success = runner.run(issue_id=1, adw_id="adw-mr-fail")
+
+    assert success is False
+    # Trailing step must not execute after a critical MR failure.
+    trailing_step.run.assert_not_called()
+    assert "Workflow completed successfully" not in caplog.text
+    assert "Critical step 'Creating GitLab merge request' failed" in caplog.text
 
 
 def test_create_gitlab_mr_step_name() -> None:

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from rouge.core.workflow.pipeline import (
@@ -423,7 +424,7 @@ class TestGetFullPipeline:
         # Check step count (should be 7 with GitHub PR step)
         assert len(pipeline) == 7
         assert isinstance(pipeline[-1], GhPullRequestStep)
-        assert not pipeline[-1].is_critical  # PR creation is best effort
+        assert pipeline[-1].is_critical  # PR creation is critical — failures abort workflow
 
     def test_pipeline_structure_gitlab(self, monkeypatch):
         """Test full pipeline structure with GitLab platform."""
@@ -433,16 +434,14 @@ class TestGetFullPipeline:
         # Check step count (should be 7 with GitLab MR step)
         assert len(pipeline) == 7
         assert isinstance(pipeline[-1], GlabPullRequestStep)
-        assert not pipeline[-1].is_critical  # MR creation is best effort
+        assert pipeline[-1].is_critical  # MR creation is critical — failures abort workflow
 
     def test_full_plan_step_present_at_index_2(self, monkeypatch):
         """Verify FullPlanStep is present at index 2."""
         monkeypatch.delenv("DEV_SEC_OPS_PLATFORM", raising=False)
         pipeline = get_full_pipeline()
 
-        assert isinstance(
-            pipeline[2], FullPlanStep
-        ), "FullPlanStep should be at index 2"
+        assert isinstance(pipeline[2], FullPlanStep), "FullPlanStep should be at index 2"
 
     def test_conditional_pr_step_logic(self, monkeypatch):
         """Verify conditional PR/MR step logic across all platforms."""
@@ -600,3 +599,75 @@ class TestGetDirectPipeline:
             assert not isinstance(
                 step, ImplementPlanStep
             ), "Direct pipeline should use ImplementDirectStep, not ImplementPlanStep"
+
+
+class TestPlatformRoutingWithConflictingDotenv:
+    """Regression coverage for the ADW entrypoint env-loading contract.
+
+    Phase 1 moved dotenv loading out of import-time side effects and into the
+    ADW CLI entrypoint, mirroring ``rouge.cli.cli``.  These tests pin down the
+    behavior that matters operationally: a ``.env`` file in the *target
+    workspace* must win over any ambient platform default, so the pipeline
+    routes to the correct PR/MR step.
+    """
+
+    def test_target_workspace_dotenv_routes_to_gitlab(self, tmp_path, monkeypatch) -> None:
+        """Loading the target workspace .env selects the GitLab MR step."""
+        rouge_source = tmp_path / "rouge_source"
+        target_workspace = tmp_path / "target_workspace"
+        rouge_source.mkdir()
+        target_workspace.mkdir()
+        (rouge_source / ".env").write_text("DEV_SEC_OPS_PLATFORM=github\n")
+        (target_workspace / ".env").write_text("DEV_SEC_OPS_PLATFORM=gitlab\n")
+
+        # Ensure no ambient platform leaks into the test from the host shell.
+        monkeypatch.delenv("DEV_SEC_OPS_PLATFORM", raising=False)
+
+        # Simulate the entrypoint flow: cwd at the target workspace, load its .env.
+        monkeypatch.chdir(target_workspace)
+        from rouge.core.database import init_db_env
+
+        init_db_env(dotenv_path=target_workspace / ".env")
+
+        assert os.environ["DEV_SEC_OPS_PLATFORM"] == "gitlab"
+        pipeline = get_full_pipeline()
+        assert isinstance(pipeline[-1], GlabPullRequestStep)
+
+    def test_target_workspace_dotenv_routes_to_github(self, tmp_path, monkeypatch) -> None:
+        """Symmetric case: a target workspace .env pinned to github routes to GitHub."""
+        rouge_source = tmp_path / "rouge_source"
+        target_workspace = tmp_path / "target_workspace"
+        rouge_source.mkdir()
+        target_workspace.mkdir()
+        (rouge_source / ".env").write_text("DEV_SEC_OPS_PLATFORM=gitlab\n")
+        (target_workspace / ".env").write_text("DEV_SEC_OPS_PLATFORM=github\n")
+
+        monkeypatch.delenv("DEV_SEC_OPS_PLATFORM", raising=False)
+
+        monkeypatch.chdir(target_workspace)
+        from rouge.core.database import init_db_env
+
+        init_db_env(dotenv_path=target_workspace / ".env")
+
+        assert os.environ["DEV_SEC_OPS_PLATFORM"] == "github"
+        pipeline = get_full_pipeline()
+        assert isinstance(pipeline[-1], GhPullRequestStep)
+
+    def test_importing_claude_does_not_mutate_platform_env(self, monkeypatch) -> None:
+        """Control: importing the Claude provider must not perform dotenv loading.
+
+        Phase 1 removed the import-time ``load_dotenv()`` call from
+        ``rouge.core.agents.claude.claude``.  Re-importing the module without
+        running the entrypoint env probe must leave ``DEV_SEC_OPS_PLATFORM``
+        untouched.
+        """
+        monkeypatch.delenv("DEV_SEC_OPS_PLATFORM", raising=False)
+
+        # Force a fresh import so any latent module-level side effects would fire here.
+        import importlib
+
+        import rouge.core.agents.claude.claude as claude_module
+
+        importlib.reload(claude_module)
+
+        assert "DEV_SEC_OPS_PLATFORM" not in os.environ


### PR DESCRIPTION
## Description

Two related reliability fixes for the ADW workflow:

1. **PR/MR step criticality**: `PullRequestStepBase.is_critical` was `False`, meaning a failed PR or MR creation was silently swallowed and the workflow continued. This changes `is_critical` to `True` so that attempted-and-failed PR/MR creations abort the pipeline. Intentional skips (`StepResult.ok` with no URL) remain non-failing.

2. **Dotenv loading**: The `load_dotenv()` call was buried as a module-level side effect in the Claude agent and re-exported via `rouge.core.__init__`. This meant the target workspace `.env` was often not loaded at the right time, causing `DEV_SEC_OPS_PLATFORM` and other workspace-specific overrides to be missed. Dotenv bootstrapping is now performed at the top of the `rouge-adw` CLI entrypoint (mirroring `rouge.cli.cli`), guaranteeing the workspace `.env` is applied before any workflow or pipeline code runs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change for tech debt or devx improvements)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- `PullRequestStepBase.is_critical` changed from `False` to `True` so failed PR/MR creation aborts the workflow pipeline
- `load_dotenv()` import-time side effect removed from `rouge.core.agents.claude.claude`
- Dotenv bootstrapping moved to `rouge.adw.cli` entrypoint with cwd-relative `.env` probe (mirrors `rouge.cli.cli`)
- `agent` removed from `rouge.core.__init__` re-exports to prevent premature imports triggering the old side effect
- Added workflow-abort integration tests for both `GhPullRequestStep` and `GlabPullRequestStep` failure paths
- Added `TestPlatformRoutingWithConflictingDotenv` tests pinning the env-loading contract for platform routing
- Added `test_rouge_adw_loads_workspace_dotenv_before_workflow_runs` to lock in the entrypoint loading sequence

## How to Test

- [ ] Run `pytest tests/test_workflow.py -k "critical or abort"` and confirm new abort tests pass
- [ ] Run `pytest tests/test_workflow_pipeline.py -k "TestPlatformRouting"` and confirm platform routing tests pass
- [ ] Run `pytest tests/test_adw.py -k "dotenv"` and confirm entrypoint env-loading test passes
- [ ] Run `pytest tests/test_gh_pull_request_step.py tests/test_glab_pull_request_step.py` for full PR/MR step coverage
- [ ] Manually invoke `rouge-adw` from a workspace directory containing a `.env` with `DEV_SEC_OPS_PLATFORM=gitlab` and verify a GitLab MR is created